### PR TITLE
Added support for Content Security Policy

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/print.css
+++ b/debug_toolbar/static/debug_toolbar/css/print.css
@@ -1,0 +1,3 @@
+#djDebug {
+  display:none;
+}

--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -646,3 +646,16 @@
         display: none;
     }
 }
+
+#djDebug .width-20 {
+    width: 20%;
+}
+#djDebug .width-60 {
+    width: 60%;
+}
+#djDebug .width-60 {
+    width: 60%;
+}
+#djDebug .highlighted {
+    background-color: lightgrey;
+}

--- a/debug_toolbar/static/debug_toolbar/js/jquery_existing.js
+++ b/debug_toolbar/static/debug_toolbar/js/jquery_existing.js
@@ -1,0 +1,1 @@
+var djdt = {jQuery: jQuery};

--- a/debug_toolbar/static/debug_toolbar/js/jquery_post.js
+++ b/debug_toolbar/static/debug_toolbar/js/jquery_post.js
@@ -1,0 +1,1 @@
+var djdt = {jQuery: jQuery.noConflict(true)}; window.define = _djdt_define_backup;

--- a/debug_toolbar/static/debug_toolbar/js/jquery_pre.js
+++ b/debug_toolbar/static/debug_toolbar/js/jquery_pre.js
@@ -1,0 +1,1 @@
+var _djdt_define_backup = window.define; window.define = undefined;

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -285,13 +285,21 @@
 
                 return value;
             }
+        },
+        applyStyle: function(name) {
+            $('#djDebug [data-' + name + ']').each(function() {
+                var css = {};
+                css[name] = $(this).data(name);
+                $(this).css(css);
+            });
         }
     };
     $.extend(publicAPI, {
         show_toolbar: djdt.show_toolbar,
         hide_toolbar: djdt.hide_toolbar,
         close: djdt.close,
-        cookie: djdt.cookie
+        cookie: djdt.cookie,
+        applyStyle: djdt.applyStyle
     });
     $(document).ready(djdt.init);
 })(djdt.jQuery, djdt);

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.profiling.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.profiling.js
@@ -17,4 +17,5 @@
             subcalls.hide();
         }
     });
+    djdt.applyStyle('padding-left');
 })(djdt.jQuery);

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.sql.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.sql.js
@@ -4,4 +4,7 @@
         $(this).parent().find('.djDebugCollapsed').toggle();
         $(this).parent().find('.djDebugUncollapsed').toggle();
     });
+    djdt.applyStyle('background-color');
+    djdt.applyStyle('left');
+    djdt.applyStyle('width');
 })(djdt.jQuery);

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.timer.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.timer.js
@@ -24,14 +24,17 @@
         if (endStat) {
             // Render a start through end bar
             $row.html('<td>' + stat.replace('Start', '') + '</td>' +
-                      '<td class="timeline"><div class="djDebugTimeline"><div class="djDebugLineChart" style="left:' + getLeft(stat) + '%;"><strong style="width:' + getCSSWidth(stat, endStat) + ';">&nbsp;</strong></div></div></td>' +
+                      '<td class="timeline"><div class="djDebugTimeline"><div class="djDebugLineChart"><strong>&nbsp;</strong></div></div></td>' +
                       '<td>' + (perf.timing[stat] - timingOffset) + ' (+' + (perf.timing[endStat] - perf.timing[stat]) + ')</td>');
+            $row.find('strong').css({width: getCSSWidth(stat, endStat)});
         } else {
             // Render a point in time
              $row.html('<td>' + stat + '</td>' +
-                       '<td class="timeline"><div class="djDebugTimeline"><div class="djDebugLineChart" style="left:' + getLeft(stat) + '%;"><strong style="width:2px;">&nbsp;</strong></div></div></td>' +
+                       '<td class="timeline"><div class="djDebugTimeline"><div class="djDebugLineChart"><strong>&nbsp;</strong></div></div></td>' +
                        '<td>' + (perf.timing[stat] - timingOffset) + '</td>');
+             $row.find('strong').css({width: 2});
         }
+        $row.find('djDebugLineChart').css({left: getLeft(stat) + '%'});
         $('#djDebugBrowserTimingTableBody').append($row);
     }
 

--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -5,11 +5,11 @@
 <link rel="stylesheet" href="{% static 'debug_toolbar/css/toolbar.css' %}" type="text/css" />
 {% if toolbar.config.JQUERY_URL %}
 <!-- Prevent our copy of jQuery from registering as an AMD module on sites that use RequireJS. -->
-<script>var _djdt_define_backup = window.define; window.define = undefined;</script>
+<script src="{% static 'debug_toolbar/js/jquery_pre.js' %}"></script>
 <script src="{{ toolbar.config.JQUERY_URL }}"></script>
-<script>var djdt = {jQuery: jQuery.noConflict(true)}; window.define = _djdt_define_backup;</script>
+<script src="{% static 'debug_toolbar/js/jquery_post.js' %}"></script>
 {% else %}
-<script>var djdt = {jQuery: jQuery};</script>
+<script src="{% static 'debug_toolbar/js/jquery_existing.js' %}"></script>
 {% endif %}
 <script src="{% static 'debug_toolbar/js/toolbar.js' %}"></script>
 <div id="djDebug" style="display:none;" dir="ltr"

--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -1,7 +1,5 @@
 {% load i18n %}{% load static from staticfiles %}{% load url from future %}
-<style type="text/css">
-@media print { #djDebug {display:none;}}
-</style>
+<link rel="stylesheet" href="{% static 'debug_toolbar/css/print.css' %}" type="text/css" media="print" />
 <link rel="stylesheet" href="{% static 'debug_toolbar/css/toolbar.css' %}" type="text/css" />
 {% if toolbar.config.JQUERY_URL %}
 <!-- Prevent our copy of jQuery from registering as an AMD module on sites that use RequireJS. -->
@@ -12,10 +10,10 @@
 <script src="{% static 'debug_toolbar/js/jquery_existing.js' %}"></script>
 {% endif %}
 <script src="{% static 'debug_toolbar/js/toolbar.js' %}"></script>
-<div id="djDebug" style="display:none;" dir="ltr"
+<div id="djDebug" hidden dir="ltr"
      data-store-id="{{ toolbar.store_id }}" data-render-panel-url="{% url 'djdt:render_panel' %}"
      {{ toolbar.config.ROOT_TAG_EXTRA_ATTRS|safe }}>
-	<div style="display:none;" id="djDebugToolbar">
+	<div hidden id="djDebugToolbar">
 		<ul id="djDebugPanelList">
 			{% if toolbar.panels %}
 			<li><a id="djHideToolBarButton" href="#" title="{% trans "Hide toolbar" %}">{% trans "Hide" %} &#187;</a></li>
@@ -45,7 +43,7 @@
 			{% endfor %}
 		</ul>
 	</div>
-	<div style="display:none;" id="djDebugToolbarHandle">
+	<div hidden id="djDebugToolbarHandle">
 		<span title="{% trans "Show toolbar" %}" id="djShowToolBarButton">&#171;</span>
 	</div>
 	{% for panel in toolbar.panels %}

--- a/debug_toolbar/templates/debug_toolbar/panels/cache.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/cache.html
@@ -51,7 +51,7 @@
 	{% for call in calls %}
 		<tr class="{% cycle 'djDebugOdd' 'djDebugEven' %}" id="cacheMain_{{ forloop.counter }}">
 			<td class="djdt-toggle">
-				<a class="djToggleSwitch" data-toggle-name="cacheMain" data-toggle-id="{{ forloop.counter }}" data-toggle-open="+" data-toggle-close="-" href="javascript:void(0)">+</a>
+				<a class="djToggleSwitch" data-toggle-name="cacheMain" data-toggle-id="{{ forloop.counter }}" data-toggle-open="+" data-toggle-close="-" href>+</a>
 			</td>
 			<td>{{ call.time|floatformat:"4" }}</td>
 			<td>{{ call.name|escape }}</td>

--- a/debug_toolbar/templates/debug_toolbar/panels/profiling.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/profiling.html
@@ -12,12 +12,11 @@
 	</thead>
 	<tbody>
 		{% for call in func_list %}
-			<!--  style="background:{{ call.background }}" -->
 			<tr class="djDebugProfileRow{% for parent_id in call.parent_ids %} djToggleDetails_{{ parent_id }}{% endfor %}" depth="{{ call.depth }}">
 				<td>
-					<div style="padding-left: {{ call.indent }}px;">
+					<div data-padding-left="{{ call.indent }}px">
 						{% if call.has_subfuncs %}
-							<a class="djProfileToggleDetails djToggleSwitch" data-toggle-id="{{ call.id }}" data-toggle-open="+" data-toggle-close="-" href="javascript:void(0)">-</a>
+							<a class="djProfileToggleDetails djToggleSwitch" data-toggle-id="{{ call.id }}" data-toggle-open="+" data-toggle-close="-" href>-</a>
 						{% else %}
 							<span class="djNoToggleSwitch"></span>
 						{% endif %}

--- a/debug_toolbar/templates/debug_toolbar/panels/request.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/request.html
@@ -24,7 +24,7 @@
 	<h4>{% trans "Cookies" %}</h4>
 	<table>
 		<colgroup>
-			<col style="width:20%"/>
+			<col class="width-20"/>
 			<col/>
 		</colgroup>
 		<thead>
@@ -50,7 +50,7 @@
 	<h4>{% trans "Session data" %}</h4>
 	<table>
 		<colgroup>
-			<col style="width:20%"/>
+			<col class="width-20"/>
 			<col/>
 		</colgroup>
 		<thead>
@@ -76,7 +76,7 @@
 	<h4>{% trans "GET data" %}</h4>
 	<table>
 		<colgroup>
-			<col style="width:20%"/>
+			<col class="width-20"/>
 			<col/>
 		</colgroup>
 		<thead>
@@ -102,7 +102,7 @@
 	<h4>{% trans "POST data" %}</h4>
 	<table>
 		<colgroup>
-			<col style="width:20%"/>
+			<col class="width-20"/>
 			<col/>
 		</colgr
 			<tr>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql.html
@@ -3,7 +3,7 @@
 	<ul class="djdt-stats">
 		{% for alias, info in databases %}
 			<li>
-				<strong class="djdt-label"><span style="background-color: rgb({{ info.rgb_color|join:", " }})" class="djdt-color">&#160;</span> {{ alias }}</strong>
+				<strong class="djdt-label"><span data-background-color="rgb({{ info.rgb_color|join:", " }})" class="djdt-color">&#160;</span> {{ alias }}</strong>
 				<span class="djdt-info">{{ info.time_spent|floatformat:"2" }} ms ({% blocktrans count info.num_queries as num %}{{ num }} query{% plural %}{{ num }} queries{% endblocktrans %})</span>
 			</li>
 		{% endfor %}
@@ -24,9 +24,9 @@
 		<tbody>
 			{% for query in queries %}
 				<tr class="djDebugHoverable {% cycle 'djDebugOdd' 'djDebugEven' %}{% if query.is_slow %} djDebugRowWarning{% endif %}{% if query.starts_trans %} djDebugStartTransaction{% endif %}{% if query.ends_trans %} djDebugEndTransaction{% endif %}{% if query.in_trans %} djDebugInTransaction{% endif %}" id="sqlMain_{{ forloop.counter }}">
-					<td class="djdt-color"><span style="background-color: rgb({{ query.rgb_color|join:", " }});">&#160;</span></td>
+					<td class="djdt-color"><span data-background-color="rgb({{ query.rgb_color|join:", " }})">&#160;</span></td>
 					<td class="djdt-toggle">
-						<a class="djToggleSwitch" data-toggle-name="sqlMain" data-toggle-id="{{ forloop.counter }}" data-toggle-open="+" data-toggle-close="-" href="javascript:void(0)">+</a>
+						<a class="djToggleSwitch" data-toggle-name="sqlMain" data-toggle-id="{{ forloop.counter }}" data-toggle-open="+" data-toggle-close="-" href>+</a>
 					</td>
 					<td class="query">
 						<div class="djDebugSqlWrap">
@@ -34,7 +34,7 @@
 						</div>
 					</td>
 					<td class="timeline">
-						<div class="djDebugTimeline"><div class="djDebugLineChart{% if query.is_slow %} djDebugLineChartWarning{% endif %}" style="left:{{ query.start_offset|unlocalize }}%;"><strong style="width:{{ query.width_ratio_relative|unlocalize }}%; background-color:{{ query.trace_color }};">{{ query.width_ratio }}%</strong></div></div>
+						<div class="djDebugTimeline"><div class="djDebugLineChart{% if query.is_slow %} djDebugLineChartWarning{% endif %}" data-left="{{ query.start_offset|unlocalize }}%"><strong data-width="{{ query.width_ratio_relative|unlocalize }}%" data-background-color"{{ query.trace_color }}">{{ query.width_ratio }}%</strong></div></div>
 					</td>
 					<td class="djdt-time">
 						{{ query.duration|floatformat:"2" }}
@@ -76,7 +76,7 @@
 									{% for line in query.template_info.context %}
 									<tr>
 										<td>{{ line.num }}</td>
-										<td><code style="font-family: monospace;{% if line.highlight %}background-color: lightgrey{% endif %}">{{ line.content }}</code></td>
+										<td><code {% if line.highlight %}class="highlighted"{% endif %}>{{ line.content }}</code></td>
 									</tr>
 									{% endfor %}
 								</table>

--- a/debug_toolbar/templates/debug_toolbar/panels/templates.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/templates.html
@@ -19,7 +19,7 @@
 	{% if template.context %}
 	<dd>
 		<div class="djTemplateShowContextDiv"><a class="djTemplateShowContext"><span class="toggleArrow">&#x25B6;</span> {% trans "Toggle context" %}</a></div>
-		<div class="djTemplateHideContextDiv" style="display:none;"><code>{{ template.context }}</code></div>
+		<div class="djTemplateHideContextDiv" hidden><code>{{ template.context }}</code></div>
 	</dd>
 	{% endif %}
 {% endfor %}
@@ -35,7 +35,7 @@
 	<dt><strong>{{ key|escape }}</strong></dt>
 	<dd>
 		<div class="djTemplateShowContextDiv"><a class="djTemplateShowContext"><span class="toggleArrow">&#x25B6;</span> {% trans "Toggle context" %}</a></div>
-		<div class="djTemplateHideContextDiv" style="display:none;"><code>{{ value|escape }}</code></div>
+		<div class="djTemplateHideContextDiv" hidden><code>{{ value|escape }}</code></div>
 	</dd>
 {% endfor %}
 </dl>

--- a/debug_toolbar/templates/debug_toolbar/panels/timer.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/timer.html
@@ -2,7 +2,7 @@
 <h4>{% trans "Resource usage" %}</h4>
 <table>
 	<colgroup>
-		<col style="width:20%"/>
+		<col class="width-20"/>
 		<col/>
 	</colgroup>
 	<thead>
@@ -22,13 +22,13 @@
 </table>
 
 <!-- This hidden div is populated and displayed by code in toolbar.timer.js -->
-<div id="djDebugBrowserTiming" style="display:none">
+<div id="djDebugBrowserTiming" hidden>
 	<h4>{% trans "Browser timing" %}</h4>
 	<table>
 		<colgroup>
-			<col style="width:20%"/>
-			<col style="width:60%"/>
-			<col style="width:20%"/>
+			<col class="width-20"/>
+			<col class="width-60"/>
+			<col class="width-20"/>
 		</colgroup>
 		<thead>
 			<tr>


### PR DESCRIPTION
In order to use debug toolbar with a content security policy enabled, no
inline scripts or styles can be used. This commit replaces all `style`
attributes with CSS or javascript. It uses `data` attributes to handle
the dynamic styles, like width and color.

In addition, this required updating jQuery to 1.8, because 1.7 is not
CSP compatible.

See also #307, which began implementing CSP compatibility.