### PR TITLE
Fix RESULTS_CACHE_SIZE setting

### DIFF
--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -23,7 +23,7 @@ CONFIG_DEFAULTS = {
     'INSERT_BEFORE': '</body>',
     'JQUERY_URL': '//ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js',
     'RENDER_PANELS': None,
-    'RESULTS_STORE_SIZE': 10,
+    'RESULTS_CACHE_SIZE': 10,
     'ROOT_TAG_EXTRA_ATTRS': '',
     'SHOW_COLLAPSED': False,
     'SHOW_TOOLBAR_CALLBACK': 'debug_toolbar.middleware.show_toolbar',

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -101,7 +101,7 @@ class DebugToolbar(object):
         self.store_id = uuid.uuid4().hex
         cls = type(self)
         cls._store[self.store_id] = self
-        for _ in range(len(cls._store) - self.config['RESULTS_STORE_SIZE']):
+        for _ in range(len(cls._store) - self.config['RESULTS_CACHE_SIZE']):
             try:
                 # collections.OrderedDict
                 cls._store.popitem(last=False)


### PR DESCRIPTION
The setting RESULTS_CACHE_SIZE was being ignored, and could not be
set in any way.

Fixes issue #671 on Github.