### PR TITLE
logging: do not change the root logger's level

### DIFF
--- a/debug_toolbar/panels/logging.py
+++ b/debug_toolbar/panels/logging.py
@@ -50,7 +50,6 @@ class ThreadTrackingHandler(logging.Handler):
 
 collector = LogCollector()
 logging_handler = ThreadTrackingHandler(collector)
-logging.root.setLevel(logging.NOTSET)
 logging.root.addHandler(logging_handler)
 
 

--- a/tests/panels/test_logging.py
+++ b/tests/panels/test_logging.py
@@ -16,6 +16,10 @@ class LoggingPanelTestCase(BaseTestCase):
         self.logger = logging.getLogger(__name__)
         collector.clear_collection()
 
+        # Assume the root logger has been configured with level=DEBUG.
+        # Previously DDT forcefully set this itself to 0 (NOTSET).
+        logging.root.setLevel(logging.DEBUG)
+
     def test_happy_case(self):
         self.logger.info('Nothing to see here, move along!')
 


### PR DESCRIPTION
Fixes https://github.com/django-debug-toolbar/django-debug-toolbar/issues/572