### PR TITLE
Loading the `url` tag from the `future` library is deprecated (this will deprecate Django 1.4 support).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ env:
   - DJANGO_VERSION=1.5.5
   - DJANGO_VERSION=1.6.10
   - DJANGO_VERSION=1.7.4
+matrix:
+  exclude:
+    - python: "2.6"
+      env: DJANGO_VERSION=1.7.4
 install:
   - pip install -e .
   - pip install Django==$DJANGO_VERSION django-discover-runner sqlparse

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,9 @@ python:
   - "3.3"
   - "3.4"
 env:
-  - DJANGO_VERSION=1.4.10
   - DJANGO_VERSION=1.5.5
-  - DJANGO_VERSION=1.6.1
-matrix:
-  exclude:
-    - python: "3.2"
-      env: DJANGO_VERSION=1.4.10
-    - python: "3.3"
-      env: DJANGO_VERSION=1.4.10
-    - python: "3.4"
-      env: DJANGO_VERSION=1.4.10
+  - DJANGO_VERSION=1.6.10
+  - DJANGO_VERSION=1.7.4
 install:
   - pip install -e .
   - pip install Django==$DJANGO_VERSION django-discover-runner sqlparse

--- a/README.rst
+++ b/README.rst
@@ -19,10 +19,7 @@ Here's a screenshot of the toolbar in action:
 In addition to the built-in panels, a number of third-party panels are
 contributed by the community.
 
-The current version of the Debug Toolbar is 1.2.2. It works on Django 1.4 to 1.7.
-
-If you're using Django 1.4, you will need Django ≥ 1.4.2 and Python ≥ 2.6.5.
-If you're using Django ≥ 1.5, there aren't any restrictions.
+The current version of the Debug Toolbar is 1.2.2. It works on Django 1.5 to 1.7.
 
 Documentation, including installation and configuration instructions, is
 available at http://django-debug-toolbar.readthedocs.org/.

--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static from staticfiles %}{% load url from future %}
+{% load i18n %}{% load static from staticfiles %}
 <style type="text/css">
 @media print { #djDebug {display:none;}}
 </style>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql.html
@@ -1,4 +1,4 @@
-{% load i18n l10n %}{% load static from staticfiles %}{% load url from future %}
+{% load i18n l10n %}{% load static from staticfiles %}
 <div class="djdt-clearfix">
 	<ul class="djdt-stats">
 		{% for alias, info in databases %}

--- a/debug_toolbar/templates/debug_toolbar/panels/templates.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/templates.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static from staticfiles %}{% load url from future %}
+{% load i18n %}{% load static from staticfiles %}
 <h4>{% blocktrans count template_dirs|length as template_count %}Template path{% plural %}Template paths{% endblocktrans %}</h4>
 {% if template_dirs %}
 	<ol>

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -92,9 +92,7 @@ class DebugToolbar(object):
     def should_render_panels(self):
         render_panels = self.config['RENDER_PANELS']
         if render_panels is None:
-            # Django 1.4 still supports mod_python :( Fall back to the safe
-            # and inefficient default in that case. Revert when we drop 1.4.
-            render_panels = self.request.META.get('wsgi.multiprocess', True)
+            render_panels = self.request.META['wsgi.multiprocess']
         return render_panels
 
     def store(self):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     license='BSD',
     packages=find_packages(exclude=('tests.*', 'tests', 'example')),
     install_requires=[
-        'django>=1.4.2',
+        'django>=1.5',
         'sqlparse',
     ],
     include_package_data=True,

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -88,9 +88,6 @@ class SQLPanelTestCase(BaseTestCase):
         # ensure the stacktrace is empty
         self.assertEqual([], query[1]['stacktrace'])
 
-    @unittest.skipIf(django.VERSION < (1, 5),
-                     "Django 1.4 loads the TEMPLATE_LOADERS before "
-                     "override_settings can modify the settings.")
     @override_settings(DEBUG=True, TEMPLATE_DEBUG=True,
                        TEMPLATE_LOADERS=('tests.loaders.LoaderWithSQL',))
     def test_regression_infinite_recursion(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,5 @@
 [tox]
 envlist =
-    py26-django14,
-    py27-django14,
     py26-django15,
     py27-django15,
     py32-django15,
@@ -25,18 +23,6 @@ deps =
 setenv =
     PYTHONPATH = {toxinidir}
 whitelist_externals = make
-
-[testenv:py26-django14]
-basepython = python2.6
-deps =
-    Django>=1.4,<1.5
-    {[testenv]deps}
-
-[testenv:py27-django14]
-basepython = python2.7
-deps =
-    Django>=1.4,<1.5
-    {[testenv]deps}
 
 [testenv:py26-django15]
 basepython = python2.6


### PR DESCRIPTION
Using the `url` tag directly has been supported for quite a while.

```
django/templatetags/future.py:24: RemovedInDjango19Warning: Loading the`url` tag from the `future`
library is deprecated and will be removed in Django 1.9. Use the default `url` tag instead.
```