### PR TITLE
Compatibility refactor

### DIFF
--- a/debug_toolbar/compat.py
+++ b/debug_toolbar/compat.py
@@ -5,6 +5,13 @@ In order to avoid circular references, nothing should be imported from
 debug_toolbar.
 """
 
+
+try:
+    from django.core.cache import CacheHandler, caches
+except ImportError:  # Django < 1.7
+    CacheHandler = None
+    caches = None
+
 try:
     from django.template.engine import Engine
 except ImportError:  # < Django 1.8

--- a/debug_toolbar/compat.py
+++ b/debug_toolbar/compat.py
@@ -5,6 +5,7 @@ In order to avoid circular references, nothing should be imported from
 debug_toolbar.
 """
 
+from django.conf import settings
 
 try:
     from django.core.cache import CacheHandler, caches
@@ -16,7 +17,7 @@ try:
     from django.template.engine import Engine
 except ImportError:  # < Django 1.8
     Engine = None
-    from django.template.context import get_standard_processors  #NOQA
+    from django.template.context import get_standard_processors  # NOQA
     from django.template.loader import find_template_loader  # NOQA
 
 try:
@@ -45,3 +46,32 @@ try:
 except ImportError:  # >= Django 1.7
     import weakref
     WEAKREF_TYPES = weakref.ReferenceType,
+
+
+def get_template_dirs():
+    """Compatibility method to fetch the template directories."""
+    if Engine:
+        template_dirs = Engine.get_default().dirs
+    else:  # < Django 1.8
+        template_dirs = settings.TEMPLATE_DIRS
+    return template_dirs
+
+
+def get_template_loaders():
+    """Compatibility method to fetch the template loaders."""
+    if Engine:
+        loaders = Engine.get_default().template_loaders
+    else:  # < Django 1.8
+        loaders = [
+            find_template_loader(loader_name)
+            for loader_name in settings.TEMPLATE_LOADERS]
+    return loaders
+
+
+def get_template_context_processors():
+    """Compatibility method to fetch the template context processors."""
+    if Engine:
+        context_processors = Engine.get_default().template_context_processors
+    else:  # < Django 1.8
+        context_processors = get_standard_processors()
+    return context_processors

--- a/debug_toolbar/compat.py
+++ b/debug_toolbar/compat.py
@@ -1,0 +1,40 @@
+"""
+This file exists to contain all Django and Python compatibility issues.
+
+In order to avoid circular references, nothing should be imported from
+debug_toolbar.
+"""
+
+try:
+    from django.template.engine import Engine
+except ImportError:  # < Django 1.8
+    Engine = None
+    from django.template.context import get_standard_processors  #NOQA
+    from django.template.loader import find_template_loader  # NOQA
+
+try:
+    from importlib import import_module
+except ImportError:  # = python 2.6
+    from django.utils.importlib import import_module  # NOQA
+
+try:
+    from collections import OrderedDict
+except ImportError:  # < python 2.7
+    from django.utils.datastructures import SortedDict as OrderedDict  # NOQA
+
+try:
+    from django.contrib.staticfiles.testing import (
+        StaticLiveServerTestCase as LiveServerTestCase)
+except ImportError:  # < Django 1.7
+    from django.test import LiveServerTestCase  # NOQA
+
+try:
+    from django.db.backends import utils
+except ImportError:  # >= Django 1.7
+    from django.db.backends import util as utils  # NOQA
+
+try:
+    from django.dispatch.dispatcher import WEAKREF_TYPES
+except ImportError:  # >= Django 1.7
+    import weakref
+    WEAKREF_TYPES = weakref.ReferenceType,

--- a/debug_toolbar/management/commands/debugsqlshell.py
+++ b/debug_toolbar/management/commands/debugsqlshell.py
@@ -4,12 +4,10 @@ from time import time
 
 # 'debugsqlshell' is the same as the 'shell'.
 from django.core.management.commands.shell import Command               # noqa
-try:
-    from django.db.backends import utils
-except ImportError:
-    from django.db.backends import util as utils
 
 import sqlparse
+
+from debug_toolbar.compat import utils
 
 
 class PrintQueryWrapper(utils.CursorDebugWrapper):

--- a/debug_toolbar/management/commands/debugsqlshell.py
+++ b/debug_toolbar/management/commands/debugsqlshell.py
@@ -7,10 +7,10 @@ from django.core.management.commands.shell import Command               # noqa
 
 import sqlparse
 
-from debug_toolbar.compat import utils
+from debug_toolbar.compat import db_backends_util
 
 
-class PrintQueryWrapper(utils.CursorDebugWrapper):
+class PrintQueryWrapper(db_backends_util.CursorDebugWrapper):
     def execute(self, sql, params=()):
         start_time = time()
         try:
@@ -23,4 +23,4 @@ class PrintQueryWrapper(utils.CursorDebugWrapper):
             print('%s [%.2fms]' % (formatted_sql, duration))
 
 
-utils.CursorDebugWrapper = PrintQueryWrapper
+db_backends_util.CursorDebugWrapper = PrintQueryWrapper

--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -4,10 +4,6 @@ Debug Toolbar middleware
 
 from __future__ import absolute_import, unicode_literals
 
-try:
-    from importlib import import_module
-except ImportError:  # python 2.6
-    from django.utils.importlib import import_module
 import re
 import threading
 
@@ -17,6 +13,7 @@ from django.utils import six
 
 from debug_toolbar.toolbar import DebugToolbar
 from debug_toolbar import settings as dt_settings
+from debug_toolbar.compat import import_module
 
 _HTML_TYPES = ('text/html', 'application/xhtml+xml')
 # Handles python threading module bug - http://bugs.python.org/issue14308

--- a/debug_toolbar/panels/cache.py
+++ b/debug_toolbar/panels/cache.py
@@ -13,14 +13,10 @@ from django.core.cache.backends.base import BaseCache
 from django.dispatch import Signal
 from django.utils.translation import ugettext_lazy as _, ungettext
 
-try:
-    from django.core.cache import CacheHandler, caches as original_caches
-except ImportError:  # Django < 1.7
-    CacheHandler = None
-    original_caches = None
 
 from debug_toolbar import settings as dt_settings
-from debug_toolbar.compat import OrderedDict
+from debug_toolbar.compat import (
+    OrderedDict, CacheHandler, caches as original_caches)
 from debug_toolbar.panels import Panel
 from debug_toolbar.utils import (tidy_stacktrace, render_stacktrace,
                                  get_template_info, get_stack)

--- a/debug_toolbar/panels/cache.py
+++ b/debug_toolbar/panels/cache.py
@@ -18,15 +18,12 @@ try:
 except ImportError:  # Django < 1.7
     CacheHandler = None
     original_caches = None
-try:
-    from collections import OrderedDict
-except ImportError:
-    from django.utils.datastructures import SortedDict as OrderedDict
 
+from debug_toolbar import settings as dt_settings
+from debug_toolbar.compat import OrderedDict
 from debug_toolbar.panels import Panel
 from debug_toolbar.utils import (tidy_stacktrace, render_stacktrace,
                                  get_template_info, get_stack)
-from debug_toolbar import settings as dt_settings
 
 
 cache_called = Signal(providing_args=[

--- a/debug_toolbar/panels/headers.py
+++ b/debug_toolbar/panels/headers.py
@@ -1,10 +1,8 @@
 from __future__ import absolute_import, unicode_literals
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from django.utils.datastructures import SortedDict as OrderedDict
 from django.utils.translation import ugettext_lazy as _
+
+from debug_toolbar.compat import OrderedDict
 from debug_toolbar.panels import Panel
 
 

--- a/debug_toolbar/panels/settings.py
+++ b/debug_toolbar/panels/settings.py
@@ -3,11 +3,8 @@ from __future__ import absolute_import, unicode_literals
 from django.conf import settings
 from django.views.debug import get_safe_settings
 from django.utils.translation import ugettext_lazy as _
-try:
-    from collections import OrderedDict
-except ImportError:
-    from django.utils.datastructures import SortedDict as OrderedDict
 
+from debug_toolbar.compat import OrderedDict
 from debug_toolbar.panels import Panel
 
 

--- a/debug_toolbar/panels/signals.py
+++ b/debug_toolbar/panels/signals.py
@@ -1,9 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-try:
-    from importlib import import_module
-except ImportError:  # python 2.6
-    from django.utils.importlib import import_module
 
 from django.core.signals import (
     request_started, request_finished, got_request_exception)
@@ -11,14 +7,11 @@ from django.db.backends.signals import connection_created
 from django.db.models.signals import (
     class_prepared, pre_init, post_init, pre_save, post_save,
     pre_delete, post_delete, post_syncdb)
-try:
-    from django.dispatch.dispatcher import WEAKREF_TYPES
-except ImportError:
-    import weakref
-    WEAKREF_TYPES = weakref.ReferenceType,
+
 from django.utils.translation import ugettext_lazy as _, ungettext
 
 from debug_toolbar.panels import Panel
+from debug_toolbar.compat import import_module, WEAKREF_TYPES
 
 
 class SignalsPanel(Panel):

--- a/debug_toolbar/panels/staticfiles.py
+++ b/debug_toolbar/panels/staticfiles.py
@@ -13,12 +13,9 @@ from django.contrib.staticfiles.templatetags import staticfiles
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import LazyObject
 from django.utils.translation import ungettext, ugettext_lazy as _
-try:
-    from collections import OrderedDict
-except ImportError:
-    from django.utils.datastructures import SortedDict as OrderedDict
 
 from debug_toolbar import panels
+from debug_toolbar.compat import OrderedDict
 from debug_toolbar.utils import ThreadCollector
 
 

--- a/debug_toolbar/panels/templates/panel.py
+++ b/debug_toolbar/panels/templates/panel.py
@@ -5,7 +5,6 @@ from pprint import pformat
 
 import django
 from django import http
-from django.conf import settings
 from django.conf.urls import url
 from django.db.models.query import QuerySet, RawQuerySet
 from django.template import Context, RequestContext, Template
@@ -15,7 +14,8 @@ from django.utils.encoding import force_text
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 
-from debug_toolbar.compat import OrderedDict, Engine, get_standard_processors
+from debug_toolbar.compat import (
+    OrderedDict, get_template_dirs, get_template_context_processors)
 from debug_toolbar.panels import Panel
 from debug_toolbar.panels.sql.tracking import recording, SQLQueryTriggered
 from debug_toolbar.panels.templates import views
@@ -47,10 +47,7 @@ def _request_context__init__(
         processors = tuple(processors)
     self.context_processors = OrderedDict()
     updates = dict()
-    if Engine:
-        std_processors = Engine.get_default().template_context_processors
-    else:
-        std_processors = get_standard_processors()
+    std_processors = get_template_context_processors()
     for processor in std_processors + processors:
         name = '%s.%s' % (processor.__module__, processor.__name__)
         context = processor(request)
@@ -191,10 +188,7 @@ class TemplatesPanel(Panel):
         else:
             context_processors = None
 
-        if Engine:
-            template_dirs = Engine.get_default().dirs
-        else:
-            template_dirs = settings.TEMPLATE_DIRS
+        template_dirs = get_template_dirs()
 
         self.record_stats({
             'templates': template_context,

--- a/debug_toolbar/panels/templates/panel.py
+++ b/debug_toolbar/panels/templates/panel.py
@@ -1,9 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from django.utils.datastructures import SortedDict as OrderedDict
 from os.path import normpath
 from pprint import pformat
 
@@ -19,15 +15,11 @@ from django.utils.encoding import force_text
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 
+from debug_toolbar.compat import OrderedDict, Engine, get_standard_processors
 from debug_toolbar.panels import Panel
 from debug_toolbar.panels.sql.tracking import recording, SQLQueryTriggered
 from debug_toolbar.panels.templates import views
 
-try:
-    from django.template.engine import Engine
-except ImportError:
-    Engine = None
-    from django.template.context import get_standard_processors
 
 # Monkey-patch to enable the template_rendered signal. The receiver returns
 # immediately when the panel is disabled to keep the overhead small.

--- a/debug_toolbar/panels/templates/views.py
+++ b/debug_toolbar/panels/templates/views.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.http import HttpResponseBadRequest
-from django.conf import settings
 from django.shortcuts import render_to_response
 from django.template import TemplateDoesNotExist
 from django.utils.safestring import mark_safe
 
-from debug_toolbar.compat import Engine, find_template_loader
+from debug_toolbar.compat import get_template_loaders
 
 
 def template_source(request):
@@ -19,10 +18,7 @@ def template_source(request):
         return HttpResponseBadRequest('"template" key is required')
 
     final_loaders = []
-    if Engine:
-        loaders = Engine.get_default().template_loaders
-    else:
-        loaders = [find_template_loader(loader_name) for loader_name in settings.TEMPLATE_LOADERS]
+    loaders = get_template_loaders()
 
     for loader in loaders:
         if loader is not None:

--- a/debug_toolbar/panels/templates/views.py
+++ b/debug_toolbar/panels/templates/views.py
@@ -6,11 +6,8 @@ from django.shortcuts import render_to_response
 from django.template import TemplateDoesNotExist
 from django.utils.safestring import mark_safe
 
-try:
-    from django.template.engine import Engine
-except ImportError:
-    Engine = None
-    from django.template.loader import find_template_loader
+from debug_toolbar.compat import Engine, find_template_loader
+
 
 def template_source(request):
     """

--- a/debug_toolbar/panels/versions.py
+++ b/debug_toolbar/panels/versions.py
@@ -1,19 +1,12 @@
 from __future__ import absolute_import, unicode_literals
 
-try:
-    from importlib import import_module
-except ImportError:  # python 2.6
-    from django.utils.importlib import import_module
 import sys
 
 import django
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
-try:
-    from collections import OrderedDict
-except ImportError:
-    from django.utils.datastructures import SortedDict as OrderedDict
 
+from debug_toolbar.compat import import_module, OrderedDict
 from debug_toolbar.panels import Panel
 
 

--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -1,13 +1,11 @@
 from __future__ import absolute_import, unicode_literals
 
-try:
-    from importlib import import_module
-except ImportError:  # python 2.6
-    from django.utils.importlib import import_module
 import warnings
 
 from django.conf import settings
 from django.utils import six
+
+from debug_toolbar.compat import import_module
 
 
 # Always import this module as follows:

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -4,10 +4,6 @@ The main DebugToolbar class that loads and renders the Toolbar.
 
 from __future__ import absolute_import, unicode_literals
 
-try:
-    from importlib import import_module
-except ImportError:  # python 2.6
-    from django.utils.importlib import import_module
 import uuid
 
 import django
@@ -16,12 +12,9 @@ from django.conf.urls import url
 from django.core.exceptions import ImproperlyConfigured
 from django.template import TemplateSyntaxError
 from django.template.loader import render_to_string
-try:
-    from collections import OrderedDict
-except ImportError:
-    from django.utils.datastructures import SortedDict as OrderedDict
 
 from debug_toolbar import settings as dt_settings
+from debug_toolbar.compat import import_module, OrderedDict
 
 
 class DebugToolbar(object):

--- a/debug_toolbar/utils.py
+++ b/debug_toolbar/utils.py
@@ -1,9 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-try:
-    from importlib import import_module
-except ImportError:  # python 2.6
-    from django.utils.importlib import import_module
 import inspect
 import os.path
 import re
@@ -23,6 +19,7 @@ from django.utils import six
 from django.views.debug import linebreak_iter
 
 from .settings import CONFIG
+from debug_toolbar.compat import import_module
 
 # Figure out some paths
 django_path = os.path.realpath(os.path.dirname(django.__file__))

--- a/tests/commands/test_debugsqlshell.py
+++ b/tests/commands/test_debugsqlshell.py
@@ -4,13 +4,11 @@ import sys
 
 from django.contrib.auth.models import User
 from django.core import management
-try:
-    from django.db.backends import utils
-except ImportError:
-    from django.db.backends import util as utils
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils import six
+
+from debug_toolbar.compat import utils
 
 
 @override_settings(DEBUG=True)

--- a/tests/commands/test_debugsqlshell.py
+++ b/tests/commands/test_debugsqlshell.py
@@ -8,14 +8,14 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils import six
 
-from debug_toolbar.compat import utils
+from debug_toolbar.compat import db_backends_util
 
 
 @override_settings(DEBUG=True)
 class DebugSQLShellTestCase(TestCase):
 
     def setUp(self):
-        self.original_cursor_wrapper = utils.CursorDebugWrapper
+        self.original_cursor_wrapper = db_backends_util.CursorDebugWrapper
         # Since debugsqlshell monkey-patches django.db.backends.utils, we can
         # test it simply by loading it, without executing it. But we have to
         # undo the monkey-patch on exit.
@@ -24,7 +24,7 @@ class DebugSQLShellTestCase(TestCase):
         management.load_command_class(app_name, command_name)
 
     def tearDown(self):
-        utils.CursorDebugWrapper = self.original_cursor_wrapper
+        db_backends_util.CursorDebugWrapper = self.original_cursor_wrapper
 
     def test_command(self):
         original_stdout, sys.stdout = sys.stdout, six.StringIO()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,7 +16,7 @@ from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings
 from django.utils.unittest import skipIf, skipUnless
 
-from debug_toolbar.compat import LiveServerTestCase
+from debug_toolbar.compat import StaticLiveServerTestCase
 from debug_toolbar.middleware import DebugToolbarMiddleware, show_toolbar
 
 from .base import BaseTestCase
@@ -113,7 +113,7 @@ class DebugToolbarIntegrationTestCase(TestCase):
 @skipIf(webdriver is None, "selenium isn't installed")
 @skipUnless('DJANGO_SELENIUM_TESTS' in os.environ, "selenium tests not requested")
 @override_settings(DEBUG=True)
-class DebugToolbarLiveTestCase(LiveServerTestCase):
+class DebugToolbarLiveTestCase(StaticLiveServerTestCase):
 
     @classmethod
     def setUpClass(cls):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -12,16 +12,11 @@ try:
 except ImportError:
     webdriver = None
 
-try:
-    from django.contrib.staticfiles.testing import StaticLiveServerTestCase \
-        as LiveServerTestCase
-except ImportError:
-    # When we're using < Django 1.7
-    from django.test import LiveServerTestCase
 from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings
 from django.utils.unittest import skipIf, skipUnless
 
+from debug_toolbar.compat import LiveServerTestCase
 from debug_toolbar.middleware import DebugToolbarMiddleware, show_toolbar
 
 from .base import BaseTestCase


### PR DESCRIPTION
This PR pulls in all of the try/except ImportError logic for Django and Python version incompatibility issues. It's based off of #674 (thanks @apollo13 for getting us started) and would fix #668.

I left the threading, resource, selenium, and pygments try/except logic where it was since they are either platform or dependency issues.

I wanted to refactor the logic for the CacheHandler in debug_toolbar.panels.cache like I did for the Engine class, but it's too coupled at this point. If someone has an idea of how to do that relatively cleanly, I'm all ears.