### PR TITLE
Only import url from future when using Django < 1.5.

### DIFF
--- a/debug_toolbar/compat.py
+++ b/debug_toolbar/compat.py
@@ -5,6 +5,7 @@ In order to avoid circular references, nothing should be imported from
 debug_toolbar.
 """
 
+import django
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
@@ -92,3 +93,13 @@ def get_template_context_processors():
     else:  # Django < 1.8
         context_processors = get_standard_processors()
     return context_processors
+
+if django.VERSION[:2] < (1, 5):
+    # If the user is using Django < 1.5, then load up the url tag
+    # from future. Otherwise use the normal one. The purpose of this
+    # is to get the url template tag that supports context variables
+    # for the first argument, yet won't raise a deprecation warning
+    # about importing it from future.
+    from django.templatetags.future import url
+else:
+    from django.template.defaulttags import url  # NOQA

--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static from staticfiles %}{% load url from future %}
+{% load i18n %}{% load static from staticfiles %}{% load url from compat %}
 <style type="text/css">
 @media print { #djDebug {display:none;}}
 </style>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql.html
@@ -1,4 +1,4 @@
-{% load i18n l10n %}{% load static from staticfiles %}{% load url from future %}
+{% load i18n l10n %}{% load static from staticfiles %}{% load url from compat %}
 <div class="djdt-clearfix">
 	<ul class="djdt-stats">
 		{% for alias, info in databases %}

--- a/debug_toolbar/templates/debug_toolbar/panels/templates.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/templates.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static from staticfiles %}{% load url from future %}
+{% load i18n %}{% load static from staticfiles %}{% load url from compat %}
 <h4>{% blocktrans count template_dirs|length as template_count %}Template path{% plural %}Template paths{% endblocktrans %}</h4>
 {% if template_dirs %}
 	<ol>

--- a/debug_toolbar/templatetags/compat.py
+++ b/debug_toolbar/templatetags/compat.py
@@ -1,0 +1,10 @@
+from django.template.base import Library
+
+from ..compat import url as url_compat
+
+register = Library()
+
+
+@register.tag
+def url(parser, token):
+    return url_compat(parser, token)


### PR DESCRIPTION
In order to hide the deprecation warnings, determine what version
django is being used, then either import the url template tag
from future or import the normal url template tag.

When support for Django 1.4 drops, this change can be removed.
Fixes #706.