### PR TITLE
Support disabling panels with the names in the docs.

### DIFF
--- a/debug_toolbar/panels/__init__.py
+++ b/debug_toolbar/panels/__init__.py
@@ -24,7 +24,16 @@ class Panel(object):
     @property
     def enabled(self):
         # Check to see if settings has a default value for it
-        if get_name_from_obj(self) in dt_settings.CONFIG['DISABLE_PANELS']:
+        disabled_panels = dt_settings.CONFIG['DISABLE_PANELS']
+        panel_path = get_name_from_obj(self)
+        # Some panels such as the SQLPanel and TemplatesPanel exist in a
+        # panel module, but can be disabled without panel in the path.
+        # For that reason, replace .panel. in the path and check for that
+        # value in the disabled panels as well.
+        disable_panel = (
+            panel_path in disabled_panels or
+            panel_path.replace('.panel.', '.') in disabled_panels)
+        if disable_panel:
             default = 'off'
         else:
             default = 'on'

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -24,6 +24,14 @@ class SQLPanelTestCase(BaseTestCase):
         self.panel.disable_instrumentation()
         super(SQLPanelTestCase, self).tearDown()
 
+    def test_disabled(self):
+        config = {
+            'DISABLE_PANELS': set(['debug_toolbar.panels.sql.SQLPanel'])
+        }
+        self.assertTrue(self.panel.enabled)
+        with self.settings(DEBUG_TOOLBAR_CONFIG=config):
+            self.assertFalse(self.panel.enabled)
+
     def test_recording(self):
         self.assertEqual(len(self.panel._queries), 0)
 

--- a/tests/panels/test_template.py
+++ b/tests/panels/test_template.py
@@ -58,6 +58,15 @@ class TemplatesPanelTestCase(BaseTestCase):
         self.panel.process_response(self.request, self.response)
         self.assertIn('tests.panels.test_template.context_processor', self.panel.content)
 
+    def test_disabled(self):
+        config = {
+            'DISABLE_PANELS': set([
+                'debug_toolbar.panels.templates.TemplatesPanel'])
+        }
+        self.assertTrue(self.panel.enabled)
+        with self.settings(DEBUG_TOOLBAR_CONFIG=config):
+            self.assertFalse(self.panel.enabled)
+
 
 def context_processor(request):
     return {'content': 'set by processor'}


### PR DESCRIPTION
The docs hide the fact that the SQLPanel and TemplatesPanel live in
a panel module. The DISABLE_PANELS config option previously required
that panel module to be included in the path in order for the panel
to be disabled.

This change will check the panel's path against that config set and
then check it again with the .panel. replaced as just . against the
config set.

Doing this replace blindly will support moving any other panel from
it's own module into a package like the SQLPanel and TemplatesPanel.

Fixes #687.