### PR TITLE
Don't ignore templates without an origin

### DIFF
--- a/debug_toolbar/panels/templates/panel.py
+++ b/debug_toolbar/panels/templates/panel.py
@@ -201,12 +201,10 @@ class TemplatesPanel(Panel):
             info = {}
             # Clean up some info about templates
             template = template_data.get('template', None)
-            if not hasattr(template, 'origin'):
-                continue
-            if template.origin and template.origin.name:
+            if hasattr(template, 'origin') and template.origin and template.origin.name:
                 template.origin_name = template.origin.name
             else:
-                template.origin_name = 'No origin'
+                template.origin_name = _('No origin')
             info['template'] = template
             # Clean up context for better readability
             if self.toolbar.config['SHOW_TEMPLATE_CONTEXT']:


### PR DESCRIPTION
We're running Django 1.7 with django-jinja. For whatever reasons, the template origin isn't set, and the panel shows no template context whatsoever. Upon investigation, I discovered that the template rendered signal is indeed fired, but the template is skipped as no origin is set.

I deny any understanding of the existing code. I do not know why templates without an origin are skipped. But without this change, we aren't getting a template context in the panel, and with it, we are. So at first sight, it looks like it's safe to do. But somebody more qualified than me has to be the judge on that.

Furthermore, this code marks the 'No origin' string as translatable.