### PR TITLE
Package name column added to Versions panel.

### DIFF
--- a/debug_toolbar/panels/versions.py
+++ b/debug_toolbar/panels/versions.py
@@ -6,7 +6,7 @@ import django
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
-from debug_toolbar.compat import import_module, OrderedDict
+from debug_toolbar.compat import import_module
 from debug_toolbar.panels import Panel
 
 
@@ -24,15 +24,15 @@ class VersionsPanel(Panel):
 
     def process_response(self, request, response):
         versions = [
-            ('Python', '%d.%d.%d' % sys.version_info[:3]),
-            ('Django', self.get_app_version(django)),
+            ('Python', '', '%d.%d.%d' % sys.version_info[:3]),
+            ('Django', '', self.get_app_version(django)),
         ]
         if django.VERSION[:2] >= (1, 7):
             versions += list(self.gen_app_versions_1_7())
         else:
             versions += list(self.gen_app_versions_1_6())
         self.record_stats({
-            'versions': OrderedDict(sorted(versions, key=lambda v: v[0])),
+            'versions': sorted(versions, key=lambda v: v[0]),
             'paths': sys.path,
         })
 
@@ -43,15 +43,16 @@ class VersionsPanel(Panel):
             app = app_config.module
             version = self.get_app_version(app)
             if version:
-                yield name, version
+                yield app.__name__, name, version
 
     def gen_app_versions_1_6(self):
         for app in list(settings.INSTALLED_APPS):
-            name = app.split('.')[-1].replace('_', ' ').capitalize()
+            package = app.split('.')[-1]
+            name = package.replace('_', ' ').capitalize()
             app = import_module(app)
             version = self.get_app_version(app)
             if version:
-                yield name, version
+                yield package, name, version
 
     def get_app_version(self, app):
         if hasattr(app, 'get_version'):

--- a/debug_toolbar/templates/debug_toolbar/panels/versions.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/versions.html
@@ -2,14 +2,16 @@
 <table>
 	<thead>
 		<tr>
+			<th>{% trans "Package" %}</th>
 			<th>{% trans "Name" %}</th>
 			<th>{% trans "Version" %}</th>
 		</tr>
 	</thead>
 	<tbody>
-		{% for package, version in versions.items %}
+		{% for package, name, version in versions %}
 			<tr class="{% cycle 'djDebugOdd' 'djDebugEven' %}">
 				<td>{{ package }}</td>
+				<td>{{ name }}</td>
 				<td>{{ version }}</td>
 			</tr>
 		{% endfor %}


### PR DESCRIPTION
Hi,

Since in Django 1.7+ `ugettext` is applied to `app.verbose_name` it might be hard to identify the very package name. Here it's solved by a new `Package` column: so we know both the package name and a title it is represented in Admin contrib.