### PR TITLE
Display the count of SQL duplicates (fixes #27)

### DIFF
--- a/debug_toolbar/panels/sql/panel.py
+++ b/debug_toolbar/panels/sql/panel.py
@@ -139,6 +139,7 @@ class SQLPanel(Panel):
     def process_response(self, request, response):
         colors = contrasting_color_generator()
         trace_colors = defaultdict(lambda: next(colors))
+        query_duplicates = defaultdict(lambda: defaultdict(int))
         if self._queries:
             width_ratio_tally = 0
             factor = int(256.0 / (len(self._databases) * 2.5))
@@ -161,6 +162,8 @@ class SQLPanel(Panel):
             trans_id = None
             i = 0
             for alias, query in self._queries:
+                query_duplicates[alias][query["raw_sql"]] += 1
+
                 trans_id = query.get('trans_id')
                 last_trans_id = trans_ids.get(alias)
 
@@ -203,6 +206,30 @@ class SQLPanel(Panel):
 
             if trans_id:
                 self._queries[(i - 1)][1]['ends_trans'] = True
+
+        # Queries are duplicates only if there's as least 2 of them.
+        # Also, to hide queries, we need to give all the duplicate groups an id
+        query_duplicates = {
+            alias: {
+                query: duplicate_count
+                for query, duplicate_count in queries.items()
+                if duplicate_count >= 2
+            }
+            for alias, queries in query_duplicates.items()
+        }
+
+        for alias, query in self._queries:
+            try:
+                duplicates_count = query_duplicates[alias][query["raw_sql"]]
+                query["duplicate_count"] = duplicates_count
+            except KeyError:
+                pass
+
+        for alias, alias_info in self._databases.items():
+            try:
+                alias_info["duplicate_count"] = sum(e for e in query_duplicates[alias].values())
+            except KeyError:
+                pass
 
         self.record_stats({
             'databases': sorted(self._databases.items(), key=lambda x: -x[1]['time_spent']),

--- a/debug_toolbar/panels/sql/panel.py
+++ b/debug_toolbar/panels/sql/panel.py
@@ -209,14 +209,14 @@ class SQLPanel(Panel):
 
         # Queries are duplicates only if there's as least 2 of them.
         # Also, to hide queries, we need to give all the duplicate groups an id
-        query_duplicates = {
-            alias: {
-                query: duplicate_count
+        query_duplicates = dict(
+            (alias, dict(
+                (query, duplicate_count)
                 for query, duplicate_count in queries.items()
                 if duplicate_count >= 2
-            }
+            ))
             for alias, queries in query_duplicates.items()
-        }
+        )
 
         for alias, query in self._queries:
             try:

--- a/debug_toolbar/templates/debug_toolbar/panels/sql.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql.html
@@ -4,7 +4,10 @@
 		{% for alias, info in databases %}
 			<li>
 				<strong class="djdt-label"><span data-background-color="rgb({{ info.rgb_color|join:", " }})" class="djdt-color">&#160;</span> {{ alias }}</strong>
-				<span class="djdt-info">{{ info.time_spent|floatformat:"2" }} ms ({% blocktrans count info.num_queries as num %}{{ num }} query{% plural %}{{ num }} queries{% endblocktrans %})</span>
+				<span class="djdt-info">{{ info.time_spent|floatformat:"2" }} ms ({% blocktrans count info.num_queries as num %}{{ num }} query{% plural %}{{ num }} queries{% endblocktrans %}
+				{% if info.duplicate_count %}
+					{% blocktrans with dupes=info.duplicate_count %}including {{ dupes }} duplicates{% endblocktrans %}
+				{% endif %})</span>
 			</li>
 		{% endfor %}
 	</ul>
@@ -32,6 +35,10 @@
 						<div class="djDebugSqlWrap">
 							<div class="djDebugSql">{{ query.sql|safe }}</div>
 						</div>
+						{% if query.first_appearance and query.duplicate_count %}
+							<strong>{% blocktrans with dupes=query.duplicate_count %}Duplicated {{ dupes }} times.{% endblocktrans %}
+							</strong>
+						{% endif %}
 					</td>
 					<td class="timeline">
 						<div class="djDebugTimeline"><div class="djDebugLineChart{% if query.is_slow %} djDebugLineChartWarning{% endif %}" data-left="{{ query.start_offset|unlocalize }}%"><strong data-width="{{ query.width_ratio_relative|unlocalize }}%" data-background-color"{{ query.trace_color }}">{{ query.width_ratio }}%</strong></div></div>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql.html
@@ -35,7 +35,7 @@
 						<div class="djDebugSqlWrap">
 							<div class="djDebugSql">{{ query.sql|safe }}</div>
 						</div>
-						{% if query.first_appearance and query.duplicate_count %}
+						{% if query.duplicate_count %}
 							<strong>{% blocktrans with dupes=query.duplicate_count %}Duplicated {{ dupes }} times.{% endblocktrans %}
 							</strong>
 						{% endif %}


### PR DESCRIPTION
This if my most successful approach at fixing #27

If we stick to just displaying the number of duplicates for each database connection and each query, we get some information, and it will help debugging.

I've been trying to push it a bit further and trying to display only the unique queries at first, with a simple way of showing everything and clear way to understand the groups but I couldn't get something easily understandable without changing the whole UI (which may be interesting, but is definitely out of the scope of this ticket).

That being said, I have some ideas and I'll try to implement something at some point.