### PR TITLE
Update the cache panel to support the cache_page decorator.

### DIFF
--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -75,7 +75,7 @@ Cache
 
 Path: ``debug_toolbar.panels.cache.CachePanel``
 
-Cache queries.
+Cache queries. Is incompatible with Django's per-site caching.
 
 Signal
 ~~~~~~

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -86,6 +86,14 @@ class DebugToolbarTestCase(BaseTestCase):
         # check toolbar insertion before "</body>"
         self.assertContains(resp, '</div>\n</body>')
 
+    def test_cache_page(self):
+        self.client.get('/cached_view/')
+        self.assertEqual(
+            len(self.toolbar.get_panel_by_id('CachePanel').calls), 3)
+        self.client.get('/cached_view/')
+        self.assertEqual(
+            len(self.toolbar.get_panel_by_id('CachePanel').calls), 5)
+
 
 @override_settings(DEBUG=True)
 class DebugToolbarIntegrationTestCase(TestCase):

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -20,5 +20,6 @@ urlpatterns = patterns('tests.views',                                   # noqa
     url(r'^non_ascii_request/$', 'regular_view', {'title': NonAsciiRepr()}),
     url(r'^new_user/$', 'new_user'),
     url(r'^execute_sql/$', 'execute_sql'),
+    url(r'^cached_view/$', 'cached_view'),
     url(r'^__debug__/', include(debug_toolbar.urls)),
 )

--- a/tests/views.py
+++ b/tests/views.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, unicode_literals
 from django.contrib.auth.models import User
 from django.http import HttpResponse
 from django.shortcuts import render
+from django.views.decorators.cache import cache_page
 
 
 def execute_sql(request):
@@ -23,4 +24,9 @@ def new_user(request, username='joe'):
 
 def resolving_view(request, arg1, arg2):
     # see test_url_resolving in tests.py
+    return HttpResponse()
+
+
+@cache_page(60)
+def cached_view(request):
     return HttpResponse()


### PR DESCRIPTION
Unfortunately, once the CacheMiddleware's caches/get_cache has been
monkey patched, it can't be disabled. This results in a bit of overhead.

Fixes #718 