### PR TITLE
Adding a color information to distinguish duplicate queries

### DIFF
--- a/debug_toolbar/panels/sql/panel.py
+++ b/debug_toolbar/panels/sql/panel.py
@@ -209,9 +209,10 @@ class SQLPanel(Panel):
 
         # Queries are duplicates only if there's as least 2 of them.
         # Also, to hide queries, we need to give all the duplicate groups an id
+        query_colors = contrasting_color_generator()
         query_duplicates = dict(
             (alias, dict(
-                (query, duplicate_count)
+                (query, (duplicate_count, next(query_colors)))
                 for query, duplicate_count in queries.items()
                 if duplicate_count >= 2
             ))
@@ -220,14 +221,15 @@ class SQLPanel(Panel):
 
         for alias, query in self._queries:
             try:
-                duplicates_count = query_duplicates[alias][query["raw_sql"]]
+                duplicates_count, color = query_duplicates[alias][query["raw_sql"]]
                 query["duplicate_count"] = duplicates_count
+                query["duplicate_color"] = color
             except KeyError:
                 pass
 
         for alias, alias_info in self._databases.items():
             try:
-                alias_info["duplicate_count"] = sum(e for e in query_duplicates[alias].values())
+                alias_info["duplicate_count"] = sum(e[0] for e in query_duplicates[alias].values())
             except KeyError:
                 pass
 

--- a/debug_toolbar/templates/debug_toolbar/panels/sql.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql.html
@@ -36,7 +36,9 @@
 							<div class="djDebugSql">{{ query.sql|safe }}</div>
 						</div>
 						{% if query.duplicate_count %}
-							<strong>{% blocktrans with dupes=query.duplicate_count %}Duplicated {{ dupes }} times.{% endblocktrans %}
+							<strong>
+								<span data-background-color="{{ query.duplicate_color }}">&#160;</span>
+								{% blocktrans with dupes=query.duplicate_count %}Duplicated {{ dupes }} times.{% endblocktrans %}
 							</strong>
 						{% endif %}
 					</td>


### PR DESCRIPTION
This pull request simply adds a color element to distinguish between each duplicated request, as a follow-up to the conversation on #719 

This is what it would look like
![There's a colored rectangle next to each "Duplicated x times" line](https://cloud.githubusercontent.com/assets/1457576/8046066/41284a38-0e38-11e5-9430-422c0fac575b.png)

I would simply like to add a note : the SQL panel uses several techniques to generate different colors, and I feel that it would be quite simpler if it was done using ``import colorsys`` (from the standard lib) which provides conversion functions from HSV (which allows selecting a color with full saturation and full value, varying only the hue from 0 to 1 instead of making convoluted operations with RGB) (As a side I'd even add that CSS supports HSL (HSL is most like HSV) input directly for most browser except IE <= 8.)

I'd be happy to redo the code for that part too, but I'm waiting for your input on that.
