### PR TITLE
Really hide the toolbar when printing

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -643,7 +643,7 @@
 
 @media print {
     #djDebug {
-        display: none;
+        display: none !important;
     }
 }
 


### PR DESCRIPTION
Use `!important` to hide the toolbar handle when printing
so it does not get overridden by inline CSS.