### PR TITLE
Generate stats - fix slow loading of media files.

### DIFF
--- a/debug_toolbar/locale/en/LC_MESSAGES/django.po
+++ b/debug_toolbar/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Django Debug Toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-05-27 19:40-0400\n"
+"POT-Creation-Date: 2015-07-06 16:50-0400\n"
 "PO-Revision-Date: 2012-03-31 20:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -20,18 +20,18 @@ msgstr ""
 msgid "Debug Toolbar"
 msgstr ""
 
-#: panels/cache.py:197
+#: panels/cache.py:209
 msgid "Cache"
 msgstr ""
 
-#: panels/cache.py:202
+#: panels/cache.py:214
 #, python-format
 msgid "%(cache_calls)d call in %(time).2fms"
 msgid_plural "%(cache_calls)d calls in %(time).2fms"
 msgstr[0] ""
 msgstr[1] ""
 
-#: panels/cache.py:210
+#: panels/cache.py:222
 #, python-format
 msgid "Cache calls from %(count)d backend"
 msgid_plural "Cache calls from %(count)d backends"
@@ -292,7 +292,7 @@ msgid "Calls"
 msgstr ""
 
 #: templates/debug_toolbar/panels/cache.html:43
-#: templates/debug_toolbar/panels/sql.html:20
+#: templates/debug_toolbar/panels/sql.html:23
 msgid "Time (ms)"
 msgstr ""
 
@@ -466,36 +466,46 @@ msgid_plural "%(num)s queries"
 msgstr[0] ""
 msgstr[1] ""
 
-#: templates/debug_toolbar/panels/sql.html:18
+#: templates/debug_toolbar/panels/sql.html:9
+#, python-format
+msgid "including %(dupes)s duplicates"
+msgstr ""
+
+#: templates/debug_toolbar/panels/sql.html:21
 msgid "Query"
 msgstr ""
 
-#: templates/debug_toolbar/panels/sql.html:19
+#: templates/debug_toolbar/panels/sql.html:22
 #: templates/debug_toolbar/panels/timer.html:36
 msgid "Timeline"
 msgstr ""
 
-#: templates/debug_toolbar/panels/sql.html:21
+#: templates/debug_toolbar/panels/sql.html:24
 msgid "Action"
 msgstr ""
 
-#: templates/debug_toolbar/panels/sql.html:64
+#: templates/debug_toolbar/panels/sql.html:39
+#, python-format
+msgid "Duplicated %(dupes)s times."
+msgstr ""
+
+#: templates/debug_toolbar/panels/sql.html:71
 msgid "Connection:"
 msgstr ""
 
-#: templates/debug_toolbar/panels/sql.html:66
+#: templates/debug_toolbar/panels/sql.html:73
 msgid "Isolation level:"
 msgstr ""
 
-#: templates/debug_toolbar/panels/sql.html:69
+#: templates/debug_toolbar/panels/sql.html:76
 msgid "Transaction status:"
 msgstr ""
 
-#: templates/debug_toolbar/panels/sql.html:83
+#: templates/debug_toolbar/panels/sql.html:90
 msgid "(unknown)"
 msgstr ""
 
-#: templates/debug_toolbar/panels/sql.html:92
+#: templates/debug_toolbar/panels/sql.html:99
 msgid "No SQL queries were recorded during this request."
 msgstr ""
 

--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -126,6 +126,10 @@ class DebugToolbarMiddleware(object):
             # When the body ends with a newline, there's two trailing groups.
             bits.append(''.join(m[0] for m in matches if m[1] == ''))
         if len(bits) > 1:
+            # When the toolbar will be inserted for sure, generate the stats.
+            for panel in reversed(toolbar.enabled_panels):
+                panel.generate_stats(request, response)
+
             bits[-2] += toolbar.render_toolbar()
             response.content = insert_before.join(bits)
             if response.get('Content-Length', None):

--- a/debug_toolbar/panels/__init__.py
+++ b/debug_toolbar/panels/__init__.py
@@ -167,10 +167,28 @@ class Panel(object):
 
     def process_response(self, request, response):
         """
-        Like process_response in Django's middleware.
+        Like process_response in Django's middleware. This is similar to
+        :meth:`generate_stats`, but will be executed on every request. It
+        should be used when either the logic needs to be executed on every
+        request or it needs to change the response entirely, such as
+        :class:`RedirectsPanel`.
 
         Write panel logic related to the response there. Post-process data
         gathered while the view executed. Save data with :meth:`record_stats`.
+
+        Return a response to overwrite the existing response.
+        """
+
+    def generate_stats(self, request, response):
+        """
+        Similar to :meth:`process_response`, but may not be executed on every
+        request. This will only be called if the toolbar will be inserted into
+        the request.
+
+        Write panel logic related to the response there. Post-process data
+        gathered while the view executed. Save data with :meth:`record_stats`.
+
+        Does not return a value.
         """
 
 

--- a/debug_toolbar/panels/__init__.py
+++ b/debug_toolbar/panels/__init__.py
@@ -168,10 +168,10 @@ class Panel(object):
     def process_response(self, request, response):
         """
         Like process_response in Django's middleware. This is similar to
-        :meth:`generate_stats`, but will be executed on every request. It
-        should be used when either the logic needs to be executed on every
-        request or it needs to change the response entirely, such as
-        :class:`RedirectsPanel`.
+        :meth:`generate_stats <debug_toolbar.panels.Panel.generate_stats>`,
+        but will be executed on every request. It should be used when either
+        the logic needs to be executed on every request or it needs to change
+        the response entirely, such as :class:`RedirectsPanel`.
 
         Write panel logic related to the response there. Post-process data
         gathered while the view executed. Save data with :meth:`record_stats`.
@@ -181,9 +181,10 @@ class Panel(object):
 
     def generate_stats(self, request, response):
         """
-        Similar to :meth:`process_response`, but may not be executed on every
-        request. This will only be called if the toolbar will be inserted into
-        the request.
+        Similar to :meth:`process_response
+        <debug_toolbar.panels.Panel.process_response>`,
+        but may not be executed on every request. This will only be called if
+        the toolbar will be inserted into the request.
 
         Write panel logic related to the response there. Post-process data
         gathered while the view executed. Save data with :meth:`record_stats`.

--- a/debug_toolbar/panels/cache.py
+++ b/debug_toolbar/panels/cache.py
@@ -244,7 +244,7 @@ class CachePanel(Panel):
             middleware_cache.caches = original_caches
         cache.get_cache = original_get_cache
 
-    def process_response(self, request, response):
+    def generate_stats(self, request, response):
         self.record_stats({
             'total_calls': len(self.calls),
             'calls': self.calls,

--- a/debug_toolbar/panels/headers.py
+++ b/debug_toolbar/panels/headers.py
@@ -47,7 +47,7 @@ class HeadersPanel(Panel):
             'environ': self.environ,
         })
 
-    def process_response(self, request, response):
+    def generate_stats(self, request, response):
         self.response_headers = OrderedDict(sorted(response.items()))
         self.record_stats({
             'response_headers': self.response_headers,

--- a/debug_toolbar/panels/logging.py
+++ b/debug_toolbar/panels/logging.py
@@ -74,7 +74,7 @@ class LoggingPanel(Panel):
     def process_request(self, request):
         collector.clear_collection()
 
-    def process_response(self, request, response):
+    def generate_stats(self, request, response):
         records = collector.get_collection()
         self._records[threading.currentThread()] = records
         collector.clear_collection()

--- a/debug_toolbar/panels/profiling.py
+++ b/debug_toolbar/panels/profiling.py
@@ -10,6 +10,11 @@ from pstats import Stats
 from colorsys import hsv_to_rgb
 import os
 
+# Occasionally the disable method on the profiler is listed before
+# the actual view functions. This function call should be ignored as
+# it leads to an error within the tests.
+INVALID_PROFILER_FUNC = "<method 'disable' of '_lsprof.Profiler' objects>"
+
 
 class DjangoDebugToolbarStats(Stats):
     __root = None
@@ -17,7 +22,7 @@ class DjangoDebugToolbarStats(Stats):
     def get_root_func(self):
         if self.__root is None:
             for func, (cc, nc, tt, ct, callers) in self.stats.items():
-                if len(callers) == 0:
+                if len(callers) == 0 and INVALID_PROFILER_FUNC not in func:
                     self.__root = func
                     break
         return self.__root

--- a/debug_toolbar/panels/profiling.py
+++ b/debug_toolbar/panels/profiling.py
@@ -142,7 +142,7 @@ class ProfilingPanel(Panel):
                     func.has_subfuncs = True
                     self.add_node(func_list, subfunc, max_depth, cum_time=cum_time)
 
-    def process_response(self, request, response):
+    def generate_stats(self, request, response):
         if not hasattr(self, 'profiler'):
             return None
         # Could be delayed until the panel content is requested (perf. optim.)

--- a/debug_toolbar/panels/profiling.py
+++ b/debug_toolbar/panels/profiling.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, unicode_literals
 
+from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 from django.utils.safestring import mark_safe
 from debug_toolbar.panels import Panel
@@ -16,13 +17,23 @@ import os
 INVALID_PROFILER_FUNC = '_lsprof.Profiler'
 
 
+def contains_profiler(func_tuple):
+    """Helper function that checks to see if the tuple contains
+    the INVALID_PROFILE_FUNC in any string value of the tuple."""
+    has_profiler = False
+    for value in func_tuple:
+        if isinstance(value, six.string_types):
+            has_profiler |= INVALID_PROFILER_FUNC in value
+    return has_profiler
+
+
 class DjangoDebugToolbarStats(Stats):
     __root = None
 
     def get_root_func(self):
         if self.__root is None:
             for func, (cc, nc, tt, ct, callers) in self.stats.items():
-                if len(callers) == 0 and INVALID_PROFILER_FUNC not in func:
+                if len(callers) == 0 and not contains_profiler(func):
                     self.__root = func
                     break
         return self.__root

--- a/debug_toolbar/panels/profiling.py
+++ b/debug_toolbar/panels/profiling.py
@@ -13,7 +13,7 @@ import os
 # Occasionally the disable method on the profiler is listed before
 # the actual view functions. This function call should be ignored as
 # it leads to an error within the tests.
-INVALID_PROFILER_FUNC = "<method 'disable' of '_lsprof.Profiler' objects>"
+INVALID_PROFILER_FUNC = '_lsprof.Profiler'
 
 
 class DjangoDebugToolbarStats(Stats):

--- a/debug_toolbar/panels/request.py
+++ b/debug_toolbar/panels/request.py
@@ -25,7 +25,7 @@ class RequestPanel(Panel):
         view_func = self.get_stats().get('view_func', '')
         return view_func.rsplit('.', 1)[-1]
 
-    def process_response(self, request, response):
+    def generate_stats(self, request, response):
         self.record_stats({
             'get': [(k, request.GET.getlist(k)) for k in sorted(request.GET)],
             'post': [(k, request.POST.getlist(k)) for k in sorted(request.POST)],

--- a/debug_toolbar/panels/settings.py
+++ b/debug_toolbar/panels/settings.py
@@ -19,7 +19,7 @@ class SettingsPanel(Panel):
     def title(self):
         return _("Settings from <code>%s</code>") % settings.SETTINGS_MODULE
 
-    def process_response(self, request, response):
+    def generate_stats(self, request, response):
         self.record_stats({
             'settings': OrderedDict(sorted(get_safe_settings().items(),
                                            key=lambda s: s[0])),

--- a/debug_toolbar/panels/signals.py
+++ b/debug_toolbar/panels/signals.py
@@ -58,7 +58,7 @@ class SignalsPanel(Panel):
             signals[signal_name] = getattr(signals_mod, signal_name)
         return signals
 
-    def process_response(self, request, response):
+    def generate_stats(self, request, response):
         signals = []
         for name, signal in sorted(self.signals.items(), key=lambda x: x[0]):
             if signal is None:

--- a/debug_toolbar/panels/sql/panel.py
+++ b/debug_toolbar/panels/sql/panel.py
@@ -136,7 +136,7 @@ class SQLPanel(Panel):
         for connection in connections.all():
             unwrap_cursor(connection)
 
-    def process_response(self, request, response):
+    def generate_stats(self, request, response):
         colors = contrasting_color_generator()
         trace_colors = defaultdict(lambda: next(colors))
         query_duplicates = defaultdict(lambda: defaultdict(int))

--- a/debug_toolbar/panels/staticfiles.py
+++ b/debug_toolbar/panels/staticfiles.py
@@ -113,7 +113,7 @@ class StaticFilesPanel(panels.Panel):
     def process_request(self, request):
         collector.clear_collection()
 
-    def process_response(self, request, response):
+    def generate_stats(self, request, response):
         used_paths = collector.get_collection()
         self._paths[threading.currentThread()] = used_paths
 

--- a/debug_toolbar/panels/templates/panel.py
+++ b/debug_toolbar/panels/templates/panel.py
@@ -195,7 +195,7 @@ class TemplatesPanel(Panel):
     def disable_instrumentation(self):
         template_rendered.disconnect(self._store_template_info)
 
-    def process_response(self, request, response):
+    def generate_stats(self, request, response):
         template_context = []
         for template_data in self.templates:
             info = {}

--- a/debug_toolbar/panels/timer.py
+++ b/debug_toolbar/panels/timer.py
@@ -52,7 +52,7 @@ class TimerPanel(Panel):
         if self.has_content:
             self._start_rusage = resource.getrusage(resource.RUSAGE_SELF)
 
-    def process_response(self, request, response):
+    def generate_stats(self, request, response):
         stats = {}
         if hasattr(self, '_start_time'):
             stats['total_time'] = (time.time() - self._start_time) * 1000

--- a/debug_toolbar/panels/versions.py
+++ b/debug_toolbar/panels/versions.py
@@ -22,7 +22,7 @@ class VersionsPanel(Panel):
 
     template = 'debug_toolbar/panels/versions.html'
 
-    def process_response(self, request, response):
+    def generate_stats(self, request, response):
         versions = [
             ('Python', '%d.%d.%d' % sys.version_info[:3]),
             ('Django', self.get_app_version(django)),

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,22 @@
 Change log
 ==========
 
+1.4
+---
+
+New features
+~~~~~~~~~~~~
+
+* New panel method :meth:`debug_toolbar.panels.Panel.generate_stats` allows panels
+  to only record stats when the toolbar is going to be inserted into the
+  response.
+
+Bugfixes
+~~~~~~~~
+
+* Response time for requests of projects with numerous media files has
+  been improved.
+
 1.3
 ---
 

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -315,6 +315,8 @@ CSS API at this time.
 
     .. automethod:: debug_toolbar.panels.Panel.process_response
 
+    .. automethod:: debug_toolbar.panels.Panel.generate_stats
+
 .. _javascript-api:
 
 JavaScript API

--- a/tests/panels/test_cache.py
+++ b/tests/panels/test_cache.py
@@ -46,3 +46,16 @@ class CachePanelTestCase(BaseTestCase):
         default_cache.set('foo', 'bar')
         second_cache.get('foo')
         self.assertEqual(len(self.panel.calls), 2)
+
+    def test_insert_content(self):
+        """
+        Test that the panel only inserts content after generate_stats and
+        not the process_response.
+        """
+        cache.cache.get('café')
+        self.panel.process_response(self.request, self.response)
+        # ensure the panel does not have content yet.
+        self.assertNotIn('café', self.panel.content)
+        self.panel.generate_stats(self.request, self.response)
+        # ensure the panel renders correctly.
+        self.assertIn('café', self.panel.content)

--- a/tests/panels/test_profiling.py
+++ b/tests/panels/test_profiling.py
@@ -23,7 +23,21 @@ class ProfilingPanelTestCase(BaseTestCase):
     def test_regular_view(self):
         self.panel.process_view(self.request, regular_view, ('profiling',), {})
         self.panel.process_response(self.request, self.response)
+        self.panel.generate_stats(self.request, self.response)
         self.assertIn('func_list', self.panel.get_stats())
+        self.assertIn('regular_view', self.panel.content)
+
+    def test_insert_content(self):
+        """
+        Test that the panel only inserts content after generate_stats and
+        not the process_response.
+        """
+        self.panel.process_view(self.request, regular_view, ('profiling',), {})
+        self.panel.process_response(self.request, self.response)
+        # ensure the panel does not have content yet.
+        self.assertNotIn('regular_view', self.panel.content)
+        self.panel.generate_stats(self.request, self.response)
+        # ensure the panel renders correctly.
         self.assertIn('regular_view', self.panel.content)
 
 

--- a/tests/panels/test_profiling.py
+++ b/tests/panels/test_profiling.py
@@ -7,7 +7,6 @@ from django.test.utils import override_settings
 
 from ..base import BaseTestCase
 from ..views import regular_view
-from debug_toolbar.compat import unittest
 
 
 @override_settings(DEBUG_TOOLBAR_PANELS=['debug_toolbar.panels.profiling.ProfilingPanel'])
@@ -17,9 +16,6 @@ class ProfilingPanelTestCase(BaseTestCase):
         super(ProfilingPanelTestCase, self).setUp()
         self.panel = self.toolbar.get_panel_by_id('ProfilingPanel')
 
-    # This test fails randomly for a reason I don't understand.
-
-    @unittest.expectedFailure
     def test_regular_view(self):
         self.panel.process_view(self.request, regular_view, ('profiling',), {})
         self.panel.process_response(self.request, self.response)

--- a/tests/panels/test_redirects.py
+++ b/tests/panels/test_redirects.py
@@ -58,3 +58,14 @@ class RedirectsPanelTestCase(BaseTestCase):
         redirect['Location'] = 'http://somewhere/else/'
         response = self.panel.process_response(self.request, redirect)
         self.assertContains(response, '369 Look Ma!')
+
+    def test_insert_content(self):
+        """
+        Test that the panel only inserts content after generate_stats and
+        not the process_response.
+        """
+        redirect = HttpResponse(status=304)
+        response = self.panel.process_response(self.request, redirect)
+        self.assertIsNotNone(response)
+        response = self.panel.generate_stats(self.request, redirect)
+        self.assertIsNone(response)

--- a/tests/panels/test_request.py
+++ b/tests/panels/test_request.py
@@ -19,6 +19,7 @@ class RequestPanelTestCase(BaseTestCase):
             self.request.session['là'.encode('utf-8')] = 'là'.encode('utf-8')
         self.panel.process_request(self.request)
         self.panel.process_response(self.request, self.response)
+        self.panel.generate_stats(self.request, self.response)
         content = self.panel.content
         if six.PY3:
             self.assertIn('où', content)
@@ -30,4 +31,18 @@ class RequestPanelTestCase(BaseTestCase):
         self.request.path = '/non_ascii_request/'
         self.panel.process_request(self.request)
         self.panel.process_response(self.request, self.response)
+        self.panel.generate_stats(self.request, self.response)
+        self.assertIn('nôt åscíì', self.panel.content)
+
+    def test_insert_content(self):
+        """
+        Test that the panel only inserts content after generate_stats and
+        not the process_response.
+        """
+        self.request.path = '/non_ascii_request/'
+        self.panel.process_response(self.request, self.response)
+        # ensure the panel does not have content yet.
+        self.assertNotIn('nôt åscíì', self.panel.content)
+        self.panel.generate_stats(self.request, self.response)
+        # ensure the panel renders correctly.
         self.assertIn('nôt åscíì', self.panel.content)

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -64,8 +64,22 @@ class SQLPanelTestCase(BaseTestCase):
         self.assertEqual(len(self.panel._queries), 3)
 
         self.panel.process_response(self.request, self.response)
+        self.panel.generate_stats(self.request, self.response)
 
         # ensure the panel renders correctly
+        self.assertIn('café', self.panel.content)
+
+    def test_insert_content(self):
+        """
+        Test that the panel only inserts content after generate_stats and
+        not the process_response.
+        """
+        list(User.objects.filter(username='café'.encode('utf-8')))
+        self.panel.process_response(self.request, self.response)
+        # ensure the panel does not have content yet.
+        self.assertNotIn('café', self.panel.content)
+        self.panel.generate_stats(self.request, self.response)
+        # ensure the panel renders correctly.
         self.assertIn('café', self.panel.content)
 
     @unittest.skipUnless(connection.vendor == 'postgresql',

--- a/tests/panels/test_staticfiles.py
+++ b/tests/panels/test_staticfiles.py
@@ -16,6 +16,7 @@ class StaticFilesPanelTestCase(BaseTestCase):
     def test_default_case(self):
         self.panel.process_request(self.request)
         self.panel.process_response(self.request, self.response)
+        self.panel.generate_stats(self.request, self.response)
         self.assertIn('django.contrib.staticfiles.finders.'
                       'AppDirectoriesFinder', self.panel.content)
         self.assertIn('django.contrib.staticfiles.finders.'
@@ -26,3 +27,18 @@ class StaticFilesPanelTestCase(BaseTestCase):
                          ['django.contrib.admin', 'debug_toolbar'])
         self.assertEqual(self.panel.get_staticfiles_dirs(),
                          finders.FileSystemFinder().locations)
+
+    def test_insert_content(self):
+        """
+        Test that the panel only inserts content after generate_stats and
+        not the process_response.
+        """
+        self.panel.process_request(self.request)
+        self.panel.process_response(self.request, self.response)
+        # ensure the panel does not have content yet.
+        self.assertNotIn('django.contrib.staticfiles.finders.'
+                         'AppDirectoriesFinder', self.panel.content)
+        self.panel.generate_stats(self.request, self.response)
+        # ensure the panel renders correctly.
+        self.assertIn('django.contrib.staticfiles.finders.'
+                      'AppDirectoriesFinder', self.panel.content)

--- a/tests/panels/test_template.py
+++ b/tests/panels/test_template.py
@@ -48,6 +48,22 @@ class TemplatesPanelTestCase(BaseTestCase):
         c = Context({'object': NonAsciiRepr()})
         t.render(c)
         self.panel.process_response(self.request, self.response)
+        self.panel.generate_stats(self.request, self.response)
+        self.assertIn('nôt åscíì', self.panel.content)
+
+    def test_insert_content(self):
+        """
+        Test that the panel only inserts content after generate_stats and
+        not the process_response.
+        """
+        t = Template("{{ object }}")
+        c = Context({'object': NonAsciiRepr()})
+        t.render(c)
+        self.panel.process_response(self.request, self.response)
+        # ensure the panel does not have content yet.
+        self.assertNotIn('nôt åscíì', self.panel.content)
+        self.panel.generate_stats(self.request, self.response)
+        # ensure the panel renders correctly.
         self.assertIn('nôt åscíì', self.panel.content)
 
     def test_custom_context_processor(self):
@@ -56,6 +72,7 @@ class TemplatesPanelTestCase(BaseTestCase):
         c = RequestContext(self.request, processors=[context_processor])
         t.render(c)
         self.panel.process_response(self.request, self.response)
+        self.panel.generate_stats(self.request, self.response)
         self.assertIn('tests.panels.test_template.context_processor', self.panel.content)
 
     def test_disabled(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -45,6 +45,7 @@ class DebugToolbarTestCase(BaseTestCase):
         panel = self.toolbar.get_panel_by_id('RequestPanel')
         panel.process_request(self.request)
         panel.process_response(self.request, self.response)
+        panel.generate_stats(self.request, self.response)
         return panel.get_stats()
 
     def test_url_resolving_positional(self):


### PR DESCRIPTION
This pull request has been created to address the slow loading of media files from issue #517.

It uses the design that @spookylukey laid out of creating a method called ```generate_stats``` that will only be called when the toolbar will be inserted into the response.