### PR TITLE
Re-add Alternate row color on profiling panel

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/panels/profiling.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/profiling.html
@@ -12,7 +12,7 @@
 	</thead>
 	<tbody>
 		{% for call in func_list %}
-			<tr class="djDebugProfileRow{% for parent_id in call.parent_ids %} djToggleDetails_{{ parent_id }}{% endfor %}" depth="{{ call.depth }}">
+			<tr class="{% cycle 'djDebugOdd' 'djDebugEven' %} djDebugProfileRow{% for parent_id in call.parent_ids %} djToggleDetails_{{ parent_id }}{% endfor %}" depth="{{ call.depth }}">
 				<td>
 					<div data-padding-left="{{ call.indent }}px">
 						{% if call.has_subfuncs %}


### PR DESCRIPTION
Previously changed in #682, was accidentally removed in https://github.com/graingert/django-debug-toolbar/commit/cf19370fbefc2c1501cb02d836735eb0beabeebc#diff-2667ca877dea7e4278072e7a381e6f99R15