### PR TITLE
Correct spelling of Django in requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     license='BSD',
     packages=find_packages(exclude=('tests.*', 'tests', 'example')),
     install_requires=[
-        'django>=1.4.2',
+        'Django>=1.4.2',
         'sqlparse',
     ],
     include_package_data=True,


### PR DESCRIPTION
It seems that using 'django' instead of 'Django' has the consequence that "pip install django_debug_toolbar" has the consequence of installing the latest version of Django, even if you already have Django installed.