### PR TITLE
Replace hidden="hidden" attribute with style="display: none;".

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -10,10 +10,10 @@
 <script src="{% static 'debug_toolbar/js/jquery_existing.js' %}"></script>
 {% endif %}
 <script src="{% static 'debug_toolbar/js/toolbar.js' %}"></script>
-<div id="djDebug" hidden="hidden" dir="ltr"
+<div id="djDebug" style="display: none;" dir="ltr"
      data-store-id="{{ toolbar.store_id }}" data-render-panel-url="{% url 'djdt:render_panel' %}"
      {{ toolbar.config.ROOT_TAG_EXTRA_ATTRS|safe }}>
-	<div hidden="hidden" id="djDebugToolbar">
+	<div style="display: none;" id="djDebugToolbar">
 		<ul id="djDebugPanelList">
 			{% if toolbar.panels %}
 			<li><a id="djHideToolBarButton" href="#" title="{% trans "Hide toolbar" %}">{% trans "Hide" %} &#187;</a></li>
@@ -43,7 +43,7 @@
 			{% endfor %}
 		</ul>
 	</div>
-	<div hidden="hidden" id="djDebugToolbarHandle">
+	<div style="display: none;" id="djDebugToolbarHandle">
 		<span title="{% trans "Show toolbar" %}" id="djShowToolBarButton">&#171;</span>
 	</div>
 	{% for panel in toolbar.panels %}

--- a/debug_toolbar/templates/debug_toolbar/panels/templates.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/templates.html
@@ -19,7 +19,7 @@
 	{% if template.context %}
 	<dd>
 		<div class="djTemplateShowContextDiv"><a class="djTemplateShowContext"><span class="toggleArrow">&#x25B6;</span> {% trans "Toggle context" %}</a></div>
-		<div class="djTemplateHideContextDiv" hidden="hidden"><code>{{ template.context }}</code></div>
+		<div class="djTemplateHideContextDiv" style="display: none;"><code>{{ template.context }}</code></div>
 	</dd>
 	{% endif %}
 {% endfor %}
@@ -35,7 +35,7 @@
 	<dt><strong>{{ key|escape }}</strong></dt>
 	<dd>
 		<div class="djTemplateShowContextDiv"><a class="djTemplateShowContext"><span class="toggleArrow">&#x25B6;</span> {% trans "Toggle context" %}</a></div>
-		<div class="djTemplateHideContextDiv" hidden="hidden"><code>{{ value|escape }}</code></div>
+		<div class="djTemplateHideContextDiv" style="display: none;"><code>{{ value|escape }}</code></div>
 	</dd>
 {% endfor %}
 </dl>

--- a/debug_toolbar/templates/debug_toolbar/panels/timer.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/timer.html
@@ -22,7 +22,7 @@
 </table>
 
 <!-- This hidden div is populated and displayed by code in toolbar.timer.js -->
-<div id="djDebugBrowserTiming" hidden="hidden">
+<div id="djDebugBrowserTiming" style="display: none;">
 	<h4>{% trans "Browser timing" %}</h4>
 	<table>
 		<colgroup>


### PR DESCRIPTION
Replaces `hidden="hidden"` attrs with `display: none` to resolve Bootstrap 4 compatibility issues described in #742.

Closes #742