### PR TITLE
Remove hidden attr when showing DjDT items and readd it when hiding.

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/jquery_showhide_plugin.js
+++ b/debug_toolbar/static/debug_toolbar/js/jquery_showhide_plugin.js
@@ -1,0 +1,22 @@
+(function ($) {
+    $.fn.djdtShow = function (duration, completeFn) {
+        this.removeAttr('hidden').show(duration, completeFn);
+        return this;
+    };
+
+    $.fn.djdtHide = function (duration, completeFn) {
+        console.log(this);
+        if (duration) {
+            var self = this;
+            this.hide(duration, function () {
+                self.attr('hidden', 'hidden');
+                if (completeFn) {
+                    completeFn.bind(self)();
+                }
+            });
+        } else {
+            this.attr('hidden', 'hidden').hide();
+        }
+        return this;
+    };
+})(djdt.jQuery);

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -6,7 +6,7 @@
         },
         isReady: false,
         init: function() {
-            $('#djDebug').removeAttr('hidden').show();
+            $('#djDebug').djdtShow();
             var current = null;
             $('#djDebugPanelList').on('click', 'li a', function() {
                 if (!this.className) {
@@ -17,7 +17,7 @@
                     $(document).trigger('close.djDebug');
                     $(this).parent().removeClass('djdt-active');
                 } else {
-                    $('.djdt-panelContent').attr('hidden', 'hidden').hide(); // Hide any that are already open
+                    $('.djdt-panelContent').djdtHide(); // Hide any that are already open
                     var inner = current.find('.djDebugPanelContent .djdt-scroll'),
                         store_id = $('#djDebug').data('store-id'),
                         render_panel_url = $('#djDebug').data('render-panel-url');
@@ -35,10 +35,10 @@
                             inner.html(data);
                         }).fail(function(xhr){
                             var message = '<div class="djDebugPanelTitle"><a class="djDebugClose djDebugBack" href=""></a><h3>'+xhr.status+': '+xhr.statusText+'</h3></div>';
-                            $('#djDebugWindow').html(message).removeAttr('hidden').show();
+                            $('#djDebugWindow').html(message).djdtShow();
                         });
                     }
-                    current.removeAttr('hidden').show();
+                    current.djdtShow();
                     $('#djDebugToolbar li').removeClass('djdt-active');
                     $(this).parent().addClass('djdt-active');
                 }
@@ -77,14 +77,14 @@
                 }
 
                 $.ajax(ajax_data).done(function(data){
-                    $('#djDebugWindow').html(data).removeAttr('hidden').show();
+                    $('#djDebugWindow').html(data).djdtShow();
                 }).fail(function(xhr){
                         var message = '<div class="djDebugPanelTitle"><a class="djDebugClose djDebugBack" href=""></a><h3>'+xhr.status+': '+xhr.statusText+'</h3></div>';
-                        $('#djDebugWindow').html(message).removeAttr('hidden').show();
+                        $('#djDebugWindow').html(message).djdtShow();
                 });
 
                 $('#djDebugWindow').on('click', 'a.djDebugBack', function() {
-                    $(this).parent().parent().attr('hidden', 'hidden').hide();
+                    $(this).parent().parent().djdtHide();
                     return false;
                 });
 
@@ -171,12 +171,12 @@
             $(document).bind('close.djDebug', function() {
                 // If a sub-panel is open, close that
                 if ($('#djDebugWindow').is(':visible')) {
-                    $('#djDebugWindow').attr('hidden', 'hidden').hide();
+                    $('#djDebugWindow').djdtHide();
                     return;
                 }
                 // If a panel is open, close that
                 if ($('.djdt-panelContent').is(':visible')) {
-                    $('.djdt-panelContent').attr('hidden', 'hidden').hide();
+                    $('.djdt-panelContent').djdtHide();
                     $('#djDebugToolbar li').removeClass('djdt-active');
                     return;
                 }
@@ -207,15 +207,13 @@
         },
         hide_toolbar: function(setCookie) {
             // close any sub panels
-            $('#djDebugWindow').attr('hidden', 'hidden').hide();
+            $('#djDebugWindow').djdtHide();
             // close all panels
-            $('.djdt-panelContent').attr('hidden', 'hidden').hide();
+            $('.djdt-panelContent').djdtHide();
             $('#djDebugToolbar li').removeClass('djdt-active');
             // finally close toolbar
-            $('#djDebugToolbar').hide('fast', function() {
-                $(this).attr('hidden', 'hidden');
-            });
-            $('#djDebugToolbarHandle').removeAttr('hidden').show();
+            $('#djDebugToolbar').djdtHide('fast');
+            $('#djDebugToolbarHandle').djdtShow();
             // set handle position
             var handleTop = djdt.cookie.get('djdttop');
             if (handleTop) {
@@ -237,11 +235,11 @@
                     djdt.close();
                 }
             });
-            $('#djDebugToolbarHandle').attr('hidden', 'hidden').hide();
+            $('#djDebugToolbarHandle').djdtHide();
             if (animate) {
-                $('#djDebugToolbar').show('fast').removeAttr('hidden');
+                $('#djDebugToolbar').djdtShow('fast');
             } else {
-                $('#djDebugToolbar').removeAttr('hidden').show();
+                $('#djDebugToolbar').djdtShow();
             }
             djdt.cookie.set('djdt', 'show', {
                 path: '/',

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -213,7 +213,7 @@
             $('#djDebugToolbar li').removeClass('djdt-active');
             // finally close toolbar
             $('#djDebugToolbar').hide('fast', function() {
-                $(this).attr('hidden', 'hidden')
+                $(this).attr('hidden', 'hidden');
             });
             $('#djDebugToolbarHandle').removeAttr('hidden').show();
             // set handle position

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -6,7 +6,7 @@
         },
         isReady: false,
         init: function() {
-            $('#djDebug').show();
+            $('#djDebug').removeAttr('hidden').show();
             var current = null;
             $('#djDebugPanelList').on('click', 'li a', function() {
                 if (!this.className) {
@@ -17,7 +17,7 @@
                     $(document).trigger('close.djDebug');
                     $(this).parent().removeClass('djdt-active');
                 } else {
-                    $('.djdt-panelContent').hide(); // Hide any that are already open
+                    $('.djdt-panelContent').attr('hidden', 'hidden').hide(); // Hide any that are already open
                     var inner = current.find('.djDebugPanelContent .djdt-scroll'),
                         store_id = $('#djDebug').data('store-id'),
                         render_panel_url = $('#djDebug').data('render-panel-url');
@@ -35,10 +35,10 @@
                             inner.html(data);
                         }).fail(function(xhr){
                             var message = '<div class="djDebugPanelTitle"><a class="djDebugClose djDebugBack" href=""></a><h3>'+xhr.status+': '+xhr.statusText+'</h3></div>';
-                            $('#djDebugWindow').html(message).show();
+                            $('#djDebugWindow').html(message).removeAttr('hidden').show();
                         });
                     }
-                    current.show();
+                    current.removeAttr('hidden').show();
                     $('#djDebugToolbar li').removeClass('djdt-active');
                     $(this).parent().addClass('djdt-active');
                 }
@@ -77,14 +77,14 @@
                 }
 
                 $.ajax(ajax_data).done(function(data){
-                    $('#djDebugWindow').html(data).show();
+                    $('#djDebugWindow').html(data).removeAttr('hidden').show();
                 }).fail(function(xhr){
                         var message = '<div class="djDebugPanelTitle"><a class="djDebugClose djDebugBack" href=""></a><h3>'+xhr.status+': '+xhr.statusText+'</h3></div>';
-                        $('#djDebugWindow').html(message).show();
+                        $('#djDebugWindow').html(message).removeAttr('hidden').show();
                 });
 
                 $('#djDebugWindow').on('click', 'a.djDebugBack', function() {
-                    $(this).parent().parent().hide();
+                    $(this).parent().parent().attr('hidden', 'hidden').hide();
                     return false;
                 });
 
@@ -171,12 +171,12 @@
             $(document).bind('close.djDebug', function() {
                 // If a sub-panel is open, close that
                 if ($('#djDebugWindow').is(':visible')) {
-                    $('#djDebugWindow').hide();
+                    $('#djDebugWindow').attr('hidden', 'hidden').hide();
                     return;
                 }
                 // If a panel is open, close that
                 if ($('.djdt-panelContent').is(':visible')) {
-                    $('.djdt-panelContent').hide();
+                    $('.djdt-panelContent').attr('hidden', 'hidden').hide();
                     $('#djDebugToolbar li').removeClass('djdt-active');
                     return;
                 }
@@ -207,13 +207,15 @@
         },
         hide_toolbar: function(setCookie) {
             // close any sub panels
-            $('#djDebugWindow').hide();
+            $('#djDebugWindow').attr('hidden', 'hidden').hide();
             // close all panels
-            $('.djdt-panelContent').hide();
+            $('.djdt-panelContent').attr('hidden', 'hidden').hide();
             $('#djDebugToolbar li').removeClass('djdt-active');
             // finally close toolbar
-            $('#djDebugToolbar').hide('fast');
-            $('#djDebugToolbarHandle').show();
+            $('#djDebugToolbar').hide('fast', function() {
+                $(this).attr('hidden', 'hidden')
+            });
+            $('#djDebugToolbarHandle').removeAttr('hidden').show();
             // set handle position
             var handleTop = djdt.cookie.get('djdttop');
             if (handleTop) {
@@ -235,11 +237,11 @@
                     djdt.close();
                 }
             });
-            $('#djDebugToolbarHandle').hide();
+            $('#djDebugToolbarHandle').attr('hidden', 'hidden').hide();
             if (animate) {
-                $('#djDebugToolbar').show('fast');
+                $('#djDebugToolbar').show('fast').removeAttr('hidden');
             } else {
-                $('#djDebugToolbar').show();
+                $('#djDebugToolbar').removeAttr('hidden').show();
             }
             djdt.cookie.set('djdt', 'show', {
                 path: '/',

--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -9,6 +9,7 @@
 {% else %}
 <script src="{% static 'debug_toolbar/js/jquery_existing.js' %}"></script>
 {% endif %}
+<script src="{% static 'debug_toolbar/js/jquery_showhide_plugin.js' %}"></script>
 <script src="{% static 'debug_toolbar/js/toolbar.js' %}"></script>
 <div id="djDebug" hidden="hidden" dir="ltr"
      data-store-id="{{ toolbar.store_id }}" data-render-panel-url="{% url 'djdt:render_panel' %}"


### PR DESCRIPTION
Another take at #742.

Removes `hidden` attribute when showing items and adds it when hiding. It does add the attr in a lot of places.

This approach does seem to break fade-in animation though. Fade-out animation is unaffected.