### PR TITLE
Fix postgres array column param serialization in tracker

### DIFF
--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -91,7 +91,10 @@ class NormalCursorWrapper(object):
 
     def _decode(self, param):
         try:
-            return force_text(param, strings_only=True)
+            if isinstance(param, list):
+                return map(self._quote_expr, param)
+            else:
+                return force_text(param, strings_only=True)
         except UnicodeDecodeError:
             return '(encoded string)'
 

--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -92,7 +92,7 @@ class NormalCursorWrapper(object):
     def _decode(self, param):
         try:
             if isinstance(param, list):
-                return map(self._quote_expr, param)
+                return map(self._decode, param)
             else:
                 return force_text(param, strings_only=True)
         except UnicodeDecodeError:


### PR DESCRIPTION
This is my attempt to tackle #747.

Teaches sql trackers `_decode` method to handle lists as params. Prior to this `force_text` would serialize each list as `u"[u'elem1',u'elem2']"` which would later cause `DataError` when fed into cursor in `sql_select` or `sql_explain` views.

This PR is "works on my machine" certified.