### PR TITLE
[WIP] Added wildcard support for INTERNAL_IPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *.DS_Store
 *~
+*.sw[po]
 build
 .coverage
 dist

--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, unicode_literals
 
 import re
 import threading
+import fnmatch
 
 from django.conf import settings
 from django.utils import six
@@ -24,13 +25,17 @@ def show_toolbar(request):
     """
     Default function to determine whether to show the toolbar on a given page.
     """
-    if request.META.get('REMOTE_ADDR', None) not in settings.INTERNAL_IPS:
-        return False
-
+    show = bool(settings.DEBUG)
+    if request.META.get('REMOTE_ADDR', None) and show:
+        for ip in settings.INTERNAL_IPS:
+            if fnmatch.fnmatch(request.META['REMOTE_ADDR'], ip):
+                show = True
+                break
+        else:
+            show = False
     if request.is_ajax():
-        return False
-
-    return bool(settings.DEBUG)
+        show = False
+    return show
 
 
 class DebugToolbarMiddleware(object):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -40,6 +40,14 @@ class DebugToolbarTestCase(BaseTestCase):
         with self.settings(INTERNAL_IPS=[]):
             self.assertFalse(show_toolbar(self.request))
 
+    def test_show_toolbar_INTERNAL_IPS_wildcard(self):
+        with self.settings(INTERNAL_IPS=['127.0.0.*']):
+            self.assertTrue(show_toolbar(self.request))
+        with self.settings(INTERNAL_IPS=['*']):
+            self.assertTrue(show_toolbar(self.request))
+        with self.settings(INTERNAL_IPS=['127.0.0.']):
+            self.assertFalse(show_toolbar(self.request))
+
     def _resolve_stats(self, path):
         # takes stats from Request panel
         self.request.path = path


### PR DESCRIPTION
Added wildcard support with [`fnmatch.fnmatch`](https://docs.python.org/2/library/fnmatch.html) in `debug_toolbar.middleware.show_toolbar`.

User can now add easily a range of IP, by example:
- `192.168.*.*` (or `192.168.*`) for match local network
- `*` for crappy dev server

If this feature is accepted, let me update documentation before merge it.