### PR TITLE
Fix typo in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ basepython =
     py32: python3.2
     py33: python3.3
     py34: python3.4
-    py34: python3.5
+    py35: python3.5
 commands = make test
 deps =
     django14: Django>=1.4,<1.5


### PR DESCRIPTION
py34 should point to python3.4, py35 to python3.5.