### PR TITLE
Fix table display

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -286,7 +286,7 @@
 	border-collapse:collapse;
 	width:100%;
 	background-color:#fff;
-	display:block;
+	display:table;
 	margin-top:0.8em;
 	overflow: auto;
 }

--- a/debug_toolbar/templates/debug_toolbar/panels/request.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/request.html
@@ -11,11 +11,11 @@
 		</tr>
 	</thead>
 	<tbody>
-		<tr>
-			<td class="djDebugOdd"><code>{{ view_func }}</code></td>
-			<td class="djDebugEven"><code>{{ view_args|pprint }}</code></td>
-			<td class="djDebugOdd"><code>{{ view_kwargs|pprint }}</code></td>
-			<td class="djDebugEven"><code>{{ view_urlname }}</code></td>
+		<tr class="djDebugOdd">
+			<td><code>{{ view_func }}</code></td>
+			<td><code>{{ view_args|pprint }}</code></td>
+			<td><code>{{ view_kwargs|pprint }}</code></td>
+			<td><code>{{ view_urlname }}</code></td>
 		</tr>
 	</tbody>
 </table>


### PR DESCRIPTION
With small text content, the columns in the settings and request panels do not fill the whole screen.
Also the colors for the view row did not look consistent.