### PR TITLE
Add VCS info panel as a third-party panel

### DIFF
--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -284,6 +284,15 @@ Path: ``debug_toolbar_user_panel.panels.UserPanel``
 
 Easily switch between logged in users, see properties of current user.
 
+VCS Info
+~~~~~~
+
+URL: https://github.com/giginet/django-debug-toolbar-vcs-info
+
+Path: ``vcs_info_panel.panels.GitInfoPanel``
+
+Displays VCS status (revision, branch, latest commit log and more) of your Django application.
+
 API for third-party panels
 --------------------------
 


### PR DESCRIPTION
I released third-party panel `django-rebug-toolbar-vcs-info` which enables to displays VCS information on the debug toolbar.

https://github.com/giginet/django-debug-toolbar-vcs-info

So I added it to the official document.

Please check it if you would like.

![](https://raw.githubusercontent.com/giginet/django-debug-toolbar-vcs-info/master/images/vcs_info_panel.png)