### PR TITLE
Update installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,7 +23,7 @@ Quick setup
 
 Make sure that ``'django.contrib.staticfiles'`` is `set up properly
 <https://docs.djangoproject.com/en/stable/howto/static-files/>`_ and add
-``'debug_toolbar'`` to your ``INSTALLED_APPS`` setting::
+``'debug_toolbar'`` **at the end** of your ``INSTALLED_APPS`` setting::
 
     INSTALLED_APPS = (
         # ...


### PR DESCRIPTION
Django admin isn't working if debug toolbar isn't at the end of INSTALLED_APS. I suggest to put it in docs.