### PR TITLE
Fixed Load Time Timeline in Timing Panel for XHTML documents

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/toolbar.timer.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.timer.js
@@ -23,16 +23,16 @@
         var $row = $('<tr class="' + ((rowCount % 2) ? 'djDebugOdd' : 'djDebugEven') + '"></tr>');
         if (endStat) {
             // Render a start through end bar
-            $row.html('<td>' + stat.replace('Start', '') + '</td>' +
-                      '<td class="timeline"><div class="djDebugTimeline"><div class="djDebugLineChart"><strong>&nbsp;</strong></div></div></td>' +
+	    $row.html('<td>' + stat.replace('Start', '') + '</td>' +
+                      '<td class="timeline"><div class="djDebugTimeline"><div class="djDebugLineChart"><strong>&#160;</strong></div></div></td>' +
                       '<td>' + (perf.timing[stat] - timingOffset) + ' (+' + (perf.timing[endStat] - perf.timing[stat]) + ')</td>');
             $row.find('strong').css({width: getCSSWidth(stat, endStat)});
         } else {
             // Render a point in time
-             $row.html('<td>' + stat + '</td>' +
-                       '<td class="timeline"><div class="djDebugTimeline"><div class="djDebugLineChart"><strong>&nbsp;</strong></div></div></td>' +
-                       '<td>' + (perf.timing[stat] - timingOffset) + '</td>');
-             $row.find('strong').css({width: 2});
+            $row.html('<td>' + stat + '</td>' +
+                      '<td class="timeline"><div class="djDebugTimeline"><div class="djDebugLineChart"><strong>&#160;</strong></div></div></td>' +
+                      '<td>' + (perf.timing[stat] - timingOffset) + '</td>');
+            $row.find('strong').css({width: 2});
         }
         $row.find('djDebugLineChart').css({left: getLeft(stat) + '%'});
         $('#djDebugBrowserTimingTableBody').append($row);


### PR DESCRIPTION
Like in Pull Request #793, the Timing Panel produces an error when used in XHTML documents. This time, the entity &amp;nbsp; is undefined for XHTML documents.

It was replaced by &amp;#160; – which is the numeric pendant. Now the panel works for all kinds of documents.