### PR TITLE
Django 1.9 is not "upcoming" anymore

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,7 @@ Change log
 1.4
 ---
 
-This version is compatible with the upcoming Django 1.9 release. It requires
+This version is compatible with Django 1.9 release and requires
 Django 1.7 or later.
 
 New features


### PR DESCRIPTION
This pull fixes a changelog, which states that 1.4 debug toolbar is compatible with "upcoming" django 1.9.