### PR TITLE
Add `white-space: normal` to CSS. Fixes #821

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -38,7 +38,7 @@
 	font-family:sans-serif;
 	text-align:left;
 	text-shadow: none;
-    white-space: normal;
+	white-space: normal;
 	-webkit-transition: none;
     -moz-transition: none;
     -o-transition: none;

--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -38,6 +38,7 @@
 	font-family:sans-serif;
 	text-align:left;
 	text-shadow: none;
+    white-space: normal;
 	-webkit-transition: none;
     -moz-transition: none;
     -o-transition: none;


### PR DESCRIPTION
Without this reset it's possible for user CSS to expand the debug
toolbar menu items. See #821 for more info.