### PR TITLE
django.core.exceptions.ImproperlyConfigured: Creating a ModelForm without either the 'fields' attribute or the 'exclude' attribute is prohibited; form TagForm needs updating.

### DIFF
--- a/debug_toolbar/toolbar/loader.py
+++ b/debug_toolbar/toolbar/loader.py
@@ -6,20 +6,14 @@ from django.template.loader import render_to_string
 
 class DebugToolbar(object):
 
-    def __init__(self, request):
-        self.request = request
-        self.panels = []
-        base_url = self.request.META.get('SCRIPT_NAME', '')
-        self.config = {
-            'INTERCEPT_REDIRECTS': True,
-            'MEDIA_URL': u'%s/__debug__/m/' % base_url
-        }
+    config = {}
+    panels = []
+    requests = {}
+    template_context = {}
+
+    def __init__(self):
         # Check if settings has a DEBUG_TOOLBAR_CONFIG and updated config
         self.config.update(getattr(settings, 'DEBUG_TOOLBAR_CONFIG', {}))
-        self.template_context = {
-            'BASE_URL': base_url, # for backwards compatibility
-            'DEBUG_TOOLBAR_MEDIA_URL': self.config.get('MEDIA_URL'),
-        }
         # Override this tuple by copying to settings.py as `DEBUG_TOOLBAR_PANELS`
         self.default_panels = (
             'debug_toolbar.panels.version.VersionDebugPanel',
@@ -34,6 +28,18 @@ class DebugToolbar(object):
             'debug_toolbar.panels.logger.LoggingPanel',
         )
         self.load_panels()
+
+    def process_request(self, request):
+        self.requests[request] = []
+        base_url = request.META.get('SCRIPT_NAME', '')
+        self.config.update({
+            'INTERCEPT_REDIRECTS': True,
+            'MEDIA_URL': u'%s/__debug__/m/' % (base_url,)
+        })
+        self.template_context.update({
+            'BASE_URL': base_url, # for backwards compatibility
+            'DEBUG_TOOLBAR_MEDIA_URL': self.config.get('MEDIA_URL'),
+        })
 
     def load_panels(self):
         """


### PR DESCRIPTION
./manage.py syncdb --noinput
Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 353, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 327, in execute
    django.setup()
  File "/usr/local/lib/python2.7/dist-packages/django/__init__.py", line 18, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/usr/local/lib/python2.7/dist-packages/django/apps/registry.py", line 108, in populate
    app_config.import_models(all_models)
  File "/usr/local/lib/python2.7/dist-packages/django/apps/config.py", line 202, in import_models
    self.models_module = import_module(models_module_name)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/opt/apps/RatticWeb/cred/models.py", line 18, in <module>
    class TagForm(ModelForm):
  File "/usr/local/lib/python2.7/dist-packages/django/forms/models.py", line 235, in __new__
    "needs updating." % name
django.core.exceptions.ImproperlyConfigured: Creating a ModelForm without either the 'fields' attribute or the 'exclude' attribute is prohibited; form TagForm needs updating.
administrator@ratticdb:/opt/apps/RatticWeb$ sudo pip install --upgrade django-debug-toolbar
Downloading/unpacking django-debug-toolbar
  Running setup.py egg_info for package django-debug-toolbar
    
Downloading/unpacking Django>=1.7 (from django-debug-toolbar)
  Running setup.py egg_info for package Django
    
    warning: no previously-included files matching '__pycache__' found under directory '*'
    warning: no previously-included files matching '*.py[co]' found under directory '*'
  Source in ./build/Django has the version 1.6, which does not match the requirement Django>=1.7 (from django-debug-toolbar)
Source in ./build/Django has version 1.6 that conflicts with Django>=1.7 (from django-debug-toolbar)
Storing complete log in /home/administrator/.pip/pip.log
administrator@ratticdb:/opt/apps/RatticWeb$ ./manage.py syncdb --noinput
Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 353, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 327, in execute
    django.setup()
  File "/usr/local/lib/python2.7/dist-packages/django/__init__.py", line 18, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/usr/local/lib/python2.7/dist-packages/django/apps/registry.py", line 108, in populate
    app_config.import_models(all_models)
  File "/usr/local/lib/python2.7/dist-packages/django/apps/config.py", line 202, in import_models
    self.models_module = import_module(models_module_name)
Please help me to solve this error
This error is occuring while i am istalling RatticDB on ubunutu 12.04 

 File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/opt/apps/RatticWeb/cred/models.py", line 18, in <module>
    class TagForm(ModelForm):
  File "/usr/local/lib/python2.7/dist-packages/django/forms/models.py", line 235, in __new__
    "needs updating." % name
django.core.exceptions.ImproperlyConfigured: Creating a ModelForm without either the 'fields' attribute or the 'exclude' attribute is prohibited; form TagForm needs updating.