### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ contributed by the community.
 The current version of the Debug Toolbar is 1.4. It works on Django ≥ 1.7.
 
 Documentation, including installation and configuration instructions, is
-available at http://django-debug-toolbar.readthedocs.org/.
+available at https://django-debug-toolbar.readthedocs.io/.
 
 The Django Debug Toolbar is released under the BSD license, like Django
 itself. If you like it, please consider contributing!


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.