### PR TITLE
Handle deprecation of app_name argument to urls.include in Django 1.9

### DIFF
--- a/debug_toolbar/__init__.py
+++ b/debug_toolbar/__init__.py
@@ -12,8 +12,10 @@ except Exception:
 
 # Code that discovers files or modules in INSTALLED_APPS imports this module.
 # Reference URLpatterns with a string to avoid the risk of circular imports.
-
-urls = 'debug_toolbar.toolbar', 'djdt', 'djdt'
-
+import django
+if django.VERSION < (1, 9):
+    urls = 'debug_toolbar.toolbar', 'djdt', 'djdt'
+else:
+    urls = 'debug_toolbar.toolbar', 'djdt'
 
 default_app_config = 'debug_toolbar.apps.DebugToolbarConfig'

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -148,4 +148,5 @@ class DebugToolbar(object):
         return cls._urlpatterns
 
 
+app_name = 'djdt'
 urlpatterns = DebugToolbar.get_urls()


### PR DESCRIPTION
Warning appears as:

RemovedInDjango20Warning: Passing a 3-tuple to
django.conf.urls.include() is deprecated. Pass a 2-tuple containing the
list of patterns and app_name, and provide the namespace argument to
include() instead.

Fixes #764