### PR TITLE
<a class="button"/> having button styles

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -45,7 +45,7 @@
     transition: none;
 }
 
-#djDebug button {
+#djDebug button, #djDebug a.button {
 	background-color: #eee;
 	background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #eee), color-stop(100%, #cccccc));
 	background-image: -webkit-linear-gradient(top, #eee, #cccccc);
@@ -65,7 +65,7 @@
 	text-shadow: 0 1px 0 #eee;
 }
 
-#djDebug button:hover {
+#djDebug button:hover, #djDebug a.button:hover {
     background-color: #ddd;
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #ddd), color-stop(100%, #bbb));
     background-image: -webkit-linear-gradient(top, #ddd, #bbb);
@@ -79,7 +79,7 @@
     text-shadow: 0 1px 0 #ddd;
 }
 
-#djDebug button:active {
+#djDebug button:active, #djDebug a.button:active {
     border: 1px solid #aaa;
     border-bottom: 1px solid #888;
     -webkit-box-shadow: inset 0 0 5px 2px #aaa, 0 1px 0 0 #eee;


### PR DESCRIPTION
The toolbar pannel of [django-uwsgi](https://github.com/alanjds/django-uwsgi) contains an ``a.button``  link that should be styled like a button.

Please share the ``button`` CSS styles with ``a.button`` or even with ``.button``