### PR TITLE
Add JAVASCRIPT_CUSTOM_ATTRIBUTE configuration

### DIFF
--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -37,7 +37,8 @@ CONFIG_DEFAULTS = {
     ),
     'PROFILER_MAX_DEPTH': 10,
     'SHOW_TEMPLATE_CONTEXT': True,
-    'SQL_WARNING_THRESHOLD': 500,   # milliseconds
+    'SQL_WARNING_THRESHOLD': 500,   # milliseconds,
+    'JAVASCRIPT_CUSTOM_ATTRIBUTE': None
 }
 
 

--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -1,15 +1,15 @@
-{% load i18n %}{% load static from staticfiles %}
+{% load i18n %}{% load static from staticfiles %}{% load debug_toolbar_extras %}
 <link rel="stylesheet" href="{% static 'debug_toolbar/css/print.css' %}" type="text/css" media="print" />
 <link rel="stylesheet" href="{% static 'debug_toolbar/css/toolbar.css' %}" type="text/css" />
 {% if toolbar.config.JQUERY_URL %}
 <!-- Prevent our copy of jQuery from registering as an AMD module on sites that use RequireJS. -->
-<script src="{% static 'debug_toolbar/js/jquery_pre.js' %}"></script>
-<script src="{{ toolbar.config.JQUERY_URL }}"></script>
-<script src="{% static 'debug_toolbar/js/jquery_post.js' %}"></script>
+<script src="{% static 'debug_toolbar/js/jquery_pre.js' %}"{% js_custom_attribute %}></script>
+<script src="{{ toolbar.config.JQUERY_URL }}"{% js_custom_attribute %}></script>
+<script src="{% static 'debug_toolbar/js/jquery_post.js' %}"{% js_custom_attribute %}></script>
 {% else %}
-<script src="{% static 'debug_toolbar/js/jquery_existing.js' %}"></script>
+<script src="{% static 'debug_toolbar/js/jquery_existing.js' %}"{% js_custom_attribute %}></script>
 {% endif %}
-<script src="{% static 'debug_toolbar/js/toolbar.js' %}"></script>
+<script src="{% static 'debug_toolbar/js/toolbar.js' %}"{% js_custom_attribute %}></script>
 <div id="djDebug" class="djdt-hidden" dir="ltr"
      data-store-id="{{ toolbar.store_id }}" data-render-panel-url="{% url 'djdt:render_panel' %}"
      {{ toolbar.config.ROOT_TAG_EXTRA_ATTRS|safe }}>

--- a/debug_toolbar/templates/debug_toolbar/panels/profiling.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/profiling.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static from staticfiles %}
+{% load i18n %}{% load static from staticfiles %}{% load debug_toolbar_extras %}
 <table width="100%">
 	<thead>
 		<tr>
@@ -33,4 +33,4 @@
 	</tbody>
 </table>
 
-<script src="{% static 'debug_toolbar/js/toolbar.profiling.js' %}"></script>
+<script src="{% static 'debug_toolbar/js/toolbar.profiling.js' %}"{% js_custom_attribute %}></script>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql.html
@@ -1,4 +1,4 @@
-{% load i18n l10n %}{% load static from staticfiles %}
+{% load i18n l10n %}{% load static from staticfiles %}{% load debug_toolbar_extras %}
 <div class="djdt-clearfix">
 	<ul class="djdt-stats">
 		{% for alias, info in databases %}
@@ -101,4 +101,4 @@
 	<p>{% trans "No SQL queries were recorded during this request." %}</p>
 {% endif %}
 
-<script src="{% static 'debug_toolbar/js/toolbar.sql.js' %}"></script>
+<script src="{% static 'debug_toolbar/js/toolbar.sql.js' %}"{% js_custom_attribute %}></script>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_explain.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_explain.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static from staticfiles %}
+{% load i18n %}{% load static from staticfiles %}{% load debug_toolbar_extras %}
 <div class="djDebugPanelTitle">
 	<a class="djDebugClose djDebugBack" href=""></a>
 	<h3>{% trans "SQL explained" %}</h3>
@@ -34,4 +34,4 @@
 	</div>
 </div>
 
-<script src="{% static 'debug_toolbar/js/toolbar.sql.js' %}"></script>
+<script src="{% static 'debug_toolbar/js/toolbar.sql.js' %}"{% js_custom_attribute %}></script>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_profile.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_profile.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static from staticfiles %}
+{% load i18n %}{% load static from staticfiles %}{% load debug_toolbar_extras %}
 <div class="djDebugPanelTitle">
 	<a class="djDebugClose djDebugBack" href=""></a>
 	<h3>{% trans "SQL profiled" %}</h3>
@@ -41,4 +41,4 @@
 	</div>
 </div>
 
-<script src="{% static 'debug_toolbar/js/toolbar.sql.js' %}"></script>
+<script src="{% static 'debug_toolbar/js/toolbar.sql.js' %}"{% js_custom_attribute %}></script>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_select.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_select.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static from staticfiles %}
+{% load i18n %}{% load static from staticfiles %}{% load debug_toolbar_extras %}
 <div class="djDebugPanelTitle">
 	<a class="djDebugClose djDebugBack" href=""></a>
 	<h3>{% trans "SQL selected" %}</h3>
@@ -38,4 +38,4 @@
 	</div>
 </div>
 
-<script src="{% static 'debug_toolbar/js/toolbar.sql.js' %}"></script>
+<script src="{% static 'debug_toolbar/js/toolbar.sql.js' %}"{% js_custom_attribute %}></script>

--- a/debug_toolbar/templates/debug_toolbar/panels/templates.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/templates.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static from staticfiles %}
+{% load i18n %}{% load static from staticfiles %}{% load debug_toolbar_extras %}
 <h4>{% blocktrans count template_dirs|length as template_count %}Template path{% plural %}Template paths{% endblocktrans %}</h4>
 {% if template_dirs %}
 	<ol>
@@ -43,4 +43,4 @@
 	<p>{% trans "None" %}</p>
 {% endif %}
 
-<script src="{% static 'debug_toolbar/js/toolbar.template.js' %}"></script>
+<script src="{% static 'debug_toolbar/js/toolbar.template.js' %}"{% js_custom_attribute %}></script>

--- a/debug_toolbar/templates/debug_toolbar/panels/timer.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/timer.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static from staticfiles %}
+{% load i18n %}{% load static from staticfiles %}{% load debug_toolbar_extras %}
 <h4>{% trans "Resource usage" %}</h4>
 <table>
 	<colgroup>
@@ -41,4 +41,4 @@
 		</tbody>
 	</table>
 </div>
-<script src="{% static 'debug_toolbar/js/toolbar.timer.js' %}"></script>
+<script src="{% static 'debug_toolbar/js/toolbar.timer.js' %}"{% js_custom_attribute %}></script>

--- a/debug_toolbar/templatetags/debug_toolbar_extras.py
+++ b/debug_toolbar/templatetags/debug_toolbar_extras.py
@@ -1,0 +1,10 @@
+from django import template
+from debug_toolbar import settings as dt_settings
+
+register = template.Library()
+
+
+@register.simple_tag
+def js_custom_attribute():
+    custom_attribute = dt_settings.get_config().get('JAVASCRIPT_CUSTOM_ATTRIBUTE')
+    return ' ' + custom_attribute if custom_attribute else ''


### PR DESCRIPTION
When I use django-debug-toolbar with custom JQUERY_URL, I need to add custom attribute to script element.
I want to use defer or async attribute.

So I added JAVASCRIPT_CUSTOM_ATTRIBUTE configuration.